### PR TITLE
Add support for inverted pair trades in price paths [ch558]

### DIFF
--- a/aggregator/trade_test.go
+++ b/aggregator/trade_test.go
@@ -25,22 +25,34 @@ import (
 
 func TestTradeAggregator(t *testing.T) {
 	pas := []*PriceAggregate{
-		newTestPricePointAggregate(0, "exchange-a", "a", "b", 2, 1),
-		newTestPricePointAggregate(0, "exchange-a", "b", "c", 4, 1),
-		newTestPricePointAggregate(0, "exchange-a", "c", "d", 1, 1),
+		newTestPricePointAggregate(0, "exchange-a", "b", "a", 4, 1),
+		newTestPricePointAggregate(0, "exchange-a", "b", "c", 8, 1),
+		newTestPricePointAggregate(0, "exchange-a", "c", "d", 2, 1),
 	}
 
-	trade := NewTrade(&Pair{Base: "a", Quote: "d"})
-
-	for _, pa := range pas {
-		trade.Ingest(pa)
-	}
-
+	trade := NewTrade()
 	res := trade.Aggregate(&Pair{Base: "a", Quote: "d"})
-	resFail := trade.Aggregate(&Pair{Base: "x", Quote: "y"})
+	assert.Nil(t, res)
+
+	trade.Ingest(pas[0])
+	res = trade.Aggregate(&Pair{Base: "b", Quote: "a"})
+	assert.NotNil(t, res)
+	assert.Equal(t, &Pair{Base: "b", Quote: "a"}, res.Pair)
+
+	trade.Ingest(pas[1])
+	res = trade.Aggregate(&Pair{Base: "a", Quote: "c"})
+	assert.NotNil(t, res)
+	assert.Equal(t, &Pair{Base: "a", Quote: "c"}, res.Pair)
+
+	trade.Ingest(pas[2])
+
+	res = trade.Aggregate(&Pair{Base: "a", Quote: "d"})
 
 	assert.NotNil(t, res)
-	assert.Equal(t, uint64(8), res.Price)
+	assert.Equal(t, &Pair{Base: "a", Quote: "d"}, res.Pair)
+	assert.Equal(t, uint64(4), res.Price)
 	assert.ElementsMatch(t, pas, res.Prices)
+
+	resFail := trade.Aggregate(&Pair{Base: "x", Quote: "y"})
 	assert.Nil(t, resFail)
 }

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -86,13 +86,23 @@ func (suite *ModelSuite) TestValidatePotentialPricePoint() {
 
 func (suite *ModelSuite) TestPricePathTarget() {
 	assert.Nil(suite.T(), PricePath{}.Target())
+	assert.Nil(suite.T(), PricePath{NewPair("a", "b"), NewPair("c", "d")}.Target())
 	assert.Equal(suite.T(), &Pair{Base: "a", Quote: "b"}, PricePath{NewPair("a", "b")}.Target())
 	assert.Equal(suite.T(), &Pair{Base: "a", Quote: "c"}, PricePath{NewPair("a", "b"), NewPair("b", "c")}.Target())
+	assert.Equal(suite.T(), &Pair{Base: "a", Quote: "c"}, PricePath{NewPair("b", "a"), NewPair("b", "c")}.Target())
+	assert.Equal(suite.T(), &Pair{Base: "c", Quote: "d"}, PricePath{NewPair("a", "b"), NewPair("b", "c"), NewPair("a", "d")}.Target())
+	assert.Equal(suite.T(), &Pair{Base: "c", Quote: "d"}, PricePath{NewPair("b", "a"), NewPair("b", "c"), NewPair("a", "d")}.Target())
+	assert.Equal(suite.T(), &Pair{Base: "c", Quote: "e"}, PricePath{NewPair("a", "b"), NewPair("b", "c"), NewPair("a", "d"), NewPair("d", "e")}.Target())
 }
 
 func (suite *ModelSuite) TestValidatePricePaths() {
-	target := NewPair("a", "c")
-	ppath := []PricePath{[]*Pair{NewPair("a", "b"), NewPair("b", "c")}}
+	target := NewPair("a", "d")
+	ppath := []PricePath{
+		[]*Pair{NewPair("a", "b"), NewPair("b", "c"), NewPair("c", "d")},
+		[]*Pair{NewPair("b", "a"), NewPair("b", "d")},
+		[]*Pair{NewPair("b", "a"), NewPair("b", "c"), NewPair("c", "d")},
+		[]*Pair{NewPair("x", "y"), NewPair("y", "a"), NewPair("x", "b"), NewPair("b", "d")},
+	}
 	ppaths := NewPricePaths(target, ppath...)
 
 	assert.Error(suite.T(), ValidatePricePaths(nil))
@@ -128,6 +138,11 @@ func (suite *ModelSuite) TestClonePriceAggregate() {
 		}),
 	)
 	assert.Equal(suite.T(), pa, pa.Clone())
+}
+
+func (suite *ModelSuite) TestClonePair() {
+	pair := NewPair("a", "b")
+	assert.Equal(suite.T(), pair, pair.Clone())
 }
 
 func (suite *ModelSuite) TestPriceToAndFromFloat() {

--- a/pather/setzer.go
+++ b/pather/setzer.go
@@ -267,11 +267,10 @@ func (sppf *Setzer) Path(target *model.Pair) *model.PricePaths {
 			[]*model.Pair{
 				model.NewPair("USDC", "USD"),
 			},
-			// TODO: This path should be added but (A/C = B/C / B/A) is not yet supported
-			//[]*model.Pair{
-			//	model.NewPair("BTC", "USDC"),
-			//	model.NewPair("BTC", "USD"),
-			//},
+			[]*model.Pair{
+				model.NewPair("BTC", "USDC"),
+				model.NewPair("BTC", "USD"),
+			},
 		)
 	case "USDT/USD":
 		return model.NewPricePaths(
@@ -279,11 +278,10 @@ func (sppf *Setzer) Path(target *model.Pair) *model.PricePaths {
 			[]*model.Pair{
 				model.NewPair("USDT", "USD"),
 			},
-			// TODO: This path should be added but (A/C = B/C / B/A) is not yet supported
-			//[]*model.Pair{
-			//	model.NewPair("BTC", "USDT"),
-			//	model.NewPair("BTC", "USD"),
-			//},
+			[]*model.Pair{
+				model.NewPair("BTC", "USDT"),
+				model.NewPair("BTC", "USD"),
+			},
 		)
 	case "WBTC/USD":
 		return model.NewPricePaths(


### PR DESCRIPTION
Support for allowing `PricePath` to follow inverted trades (eg. BTC/USDC → BTC/USD = USDC/USD)