### PR TITLE
Remove single pair aggregators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
 PACKAGE ?= gofer
-GOFILES := $(shell { git ls-files; git ls-files -o --exclude-standard; } | grep ".go$$")
+GOFILES := $(shell { git ls-files; } | grep ".go$$") # git ls-files -o --exclude-standard;
 
 OUT_DIR := workdir
 COVER_FILE := $(OUT_DIR)/cover.out
+TEST_FLAGS ?= all
 
 GO := go
 
@@ -15,11 +16,11 @@ vendor:
 .PHONY: vendor
 
 test:
-	$(GO) test ./...
+	$(GO) test -tags $(TEST_FLAGS) ./...
 .PHONY: test
 
 bench:
-	$(GO) test -bench=. ./...
+	$(GO) test -tags $(TEST_FLAGS) -bench=. ./...
 .PHONY: bench
 
 lint:
@@ -28,7 +29,7 @@ lint:
 
 cover:
 	@mkdir -p $(dir $(COVER_FILE))
-	$(GO) test -coverprofile=$(COVER_FILE) ./...
+	$(GO) test -tags $(TEST_FLAGS) -coverprofile=$(COVER_FILE) ./...
 	go tool cover -func=$(COVER_FILE)
 .PHONY: cover
 

--- a/aggregator/integration_test.go
+++ b/aggregator/integration_test.go
@@ -67,12 +67,7 @@ func TestPathWithSetzerPatherAndMedianIntegration(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		pathAggregator := NewPath(
 			ppathss,
-			func(pair *Pair) Aggregator {
-				return NewMedian(1000)
-			},
-			func(pair *Pair) Aggregator {
-				return NewIndirectMedian(pair)
-			},
+			NewMedian(1000),
 		)
 
 		randomReduce(pathAggregator, &Pair{Base: "ETH", Quote: "USD"}, pas)
@@ -103,6 +98,7 @@ func TestPathWithSetzerPatherAndMedianIntegration(t *testing.T) {
 		assert.Equal(t, &Pair{Base: "REP", Quote: "USD"}, res_REP_USD.Pair)
 		assert.Equal(t, "indirect-median", res_REP_USD.PriceModelName)
 		assert.Equal(t, uint64(0), res_REP_USD.Price)
+
 
 		res_USDC_USD := pathAggregator.Aggregate(&Pair{Base: "USDC", Quote: "USD"})
 		assert.NotNil(t, res_USDC_USD)

--- a/aggregator/median.go
+++ b/aggregator/median.go
@@ -145,35 +145,3 @@ func median(xs []uint64) uint64 {
 	i := int((count - 1) / 2)
 	return xs[i]
 }
-
-type IndirectMedian struct {
-	pair   *model.Pair
-	prices []*model.PriceAggregate
-}
-
-func NewIndirectMedian(pair *model.Pair) *IndirectMedian {
-	return &IndirectMedian{pair: pair}
-}
-
-func (im *IndirectMedian) Ingest(pa *model.PriceAggregate) {
-	if im.pair.Equal(pa.Pair) {
-		im.prices = append(im.prices, pa)
-	}
-}
-
-func (im *IndirectMedian) Aggregate(pair *model.Pair) *model.PriceAggregate {
-	if !im.pair.Equal(pair) {
-		return nil
-	}
-
-	var prices []uint64
-	for _, pa := range im.prices {
-		prices = append(prices, pa.Price)
-	}
-
-	return model.NewPriceAggregate(
-		"indirect-median",
-		&model.PricePoint{Pair: im.pair, Price: median(prices)},
-		im.prices...,
-	)
-}

--- a/aggregator/median_test.go
+++ b/aggregator/median_test.go
@@ -25,6 +25,8 @@ import (
 
 func TestOddPriceCount(t *testing.T) {
 	rows := []*PriceAggregate{
+		// nil is ignored
+		nil,
 		// Should be filtered due to outside time window
 		newTestPricePointAggregate(-1000, "exchange0", "a", "b", 1000, 1),
 		// Should be overwritten by entry 3 due to same exchange but older
@@ -32,15 +34,20 @@ func TestOddPriceCount(t *testing.T) {
 		newTestPricePointAggregate(2, "exchange2", "a", "b", 20, 1),
 		newTestPricePointAggregate(3, "exchange1", "a", "b", 3, 1),
 		// Should be skipped due to non-matching pair
-		newTestPricePointAggregate(4, "exchange4", "n", "o", 4, 1),
+		newTestPricePointAggregate(4, "exchange4", "n", "o", 1337, 1),
 		newTestPricePointAggregate(5, "exchange5", "a", "b", 5, 1),
 	}
 
 	for i := 0; i < 100; i++ {
 		reducer := NewMedian(1000)
 		pa := randomReduce(reducer, &Pair{Base: "a", Quote: "b"}, rows)
+		assert.Nil(t, reducer.Aggregate(nil))
 		assert.Equal(t, 3, len(pa.Prices), "length of aggregate price list")
 		assert.Equal(t, uint64(5), pa.Price, "aggregate price should be median of price points")
+
+		paNO := randomReduce(reducer, &Pair{Base: "n", Quote: "o"}, rows)
+		assert.Equal(t, 1, len(paNO.Prices), "length of aggregate price list")
+		assert.Equal(t, uint64(1337), paNO.Price, "aggregate price should be median of price points")
 	}
 }
 
@@ -88,32 +95,5 @@ func TestInvalidPair(t *testing.T) {
 		reducer := NewMedian(1000)
 		pa := randomReduce(reducer, &Pair{Base: "x", Quote: "y"}, rows)
 		assert.Nil(t, pa)
-	}
-}
-
-func TestIndirectMedian(t *testing.T) {
-	// Only pair and price are considered in IndirectMedian
-	pas := []*PriceAggregate{
-		newTestPricePointAggregate(99999, "", "a", "b", 2, 1),
-		newTestPricePointAggregate(3, "any exchange", "a", "b", 6, 1),
-		newTestPricePointAggregatePriceOnly(1, "", "a", "b", 20, 1),
-	}
-	ignoredPAs := []*PriceAggregate{
-		// Ignored, non matchin pair
-		newTestPricePointAggregate(4, "", "x", "y", 1001, 1),
-	}
-
-	for i := 0; i < 100; i++ {
-		reducer := NewIndirectMedian(&Pair{Base: "a", Quote: "b"})
-
-		res := randomReduce(reducer, &Pair{Base: "a", Quote: "b"}, append(pas, ignoredPAs...))
-		resFail := reducer.Aggregate(&Pair{Base: "x", Quote: "y"})
-
-		assert.NotNil(t, res)
-		assert.Equal(t, uint64(6), res.Price)
-		assert.Equal(t, &Pair{Base: "a", Quote: "b"}, res.Pair)
-		assert.ElementsMatch(t, pas, res.Prices)
-
-		assert.Nil(t, resFail)
 	}
 }

--- a/pather/pather.go
+++ b/pather/pather.go
@@ -30,26 +30,29 @@ type Pather interface {
 // FilterPotentialPricePoints returns the PotentialPricePoints that are required
 // to complete the PricePaths given and nil if path is not possible to complete
 // with the given PotentialPricePoints
-func FilterPotentialPricePoints(ppath *model.PricePaths, ppps []*model.PotentialPricePoint) []*model.PotentialPricePoint {
+func FilterPotentialPricePoints(ppaths []*model.PricePaths, ppps []*model.PotentialPricePoint) []*model.PotentialPricePoint {
 	resIndex := make(map[*model.PotentialPricePoint]bool)
-	for _, path := range ppath.Paths {
-		index := make(map[model.Pair]bool)
-		for _, pair := range path {
-			index[*pair] = true
-		}
-
-		pppIndex := make(map[*model.PotentialPricePoint]bool)
-		pairIndex := make(map[model.Pair]bool)
-		for _, ppp := range ppps {
-			if _, ok := index[*ppp.Pair]; ok {
-				pppIndex[ppp] = true
-				pairIndex[*ppp.Pair] = true
+	for _, ppath := range ppaths {
+		for _, path := range ppath.Paths {
+			index := make(map[model.Pair]bool)
+			for _, pair := range path {
+				index[*pair] = true
 			}
-		}
 
-		if len(pairIndex) == len(index) {
-			for ppp := range pppIndex {
-				resIndex[ppp] = true
+			pppIndex := make(map[*model.PotentialPricePoint]bool)
+			pairIndex := make(map[model.Pair]bool)
+			for _, ppp := range ppps {
+				pair := *ppp.Pair
+				if _, ok := index[pair]; ok {
+					pppIndex[ppp] = true
+					pairIndex[pair] = true
+				}
+			}
+
+			if len(pairIndex) == len(index) {
+				for ppp := range pppIndex {
+					resIndex[ppp] = true
+				}
 			}
 		}
 	}

--- a/pather/pather_test.go
+++ b/pather/pather_test.go
@@ -52,7 +52,7 @@ func TestPricePathETHBTC(t *testing.T) {
 	}
 
 	var pppRes []*PotentialPricePoint
-	pppRes = FilterPotentialPricePoints(ppath, ppps)
+	pppRes = FilterPotentialPricePoints([]*PricePaths{ppath}, ppps)
 	assert.NotNil(t, pppRes)
 	assert.Equal(t, pppRes, []*PotentialPricePoint{
 		{
@@ -63,7 +63,7 @@ func TestPricePathETHBTC(t *testing.T) {
 		},
 	})
 
-	pppRes = FilterPotentialPricePoints(ppath, pppsFail)
+	pppRes = FilterPotentialPricePoints([]*PricePaths{ppath}, pppsFail)
 	assert.Nil(t, pppRes)
 }
 
@@ -155,7 +155,7 @@ func TestPricePathBATUSD(t *testing.T) {
 	}
 
 	var pppRes []*PotentialPricePoint
-	pppRes = FilterPotentialPricePoints(ppath, ppps_BAT_BTC)
+	pppRes = FilterPotentialPricePoints([]*PricePaths{ppath}, ppps_BAT_BTC)
 	assert.NotNil(t, pppRes)
 	assert.ElementsMatch(t, []*PotentialPricePoint{
 		{
@@ -178,7 +178,7 @@ func TestPricePathBATUSD(t *testing.T) {
 		},
 	}, pppRes)
 
-	pppRes = FilterPotentialPricePoints(ppath, ppps_BAT_BTC_KRW)
+	pppRes = FilterPotentialPricePoints([]*PricePaths{ppath}, ppps_BAT_BTC_KRW)
 	assert.NotNil(t, pppRes)
 	assert.ElementsMatch(t, []*PotentialPricePoint{
 		{
@@ -219,6 +219,6 @@ func TestPricePathBATUSD(t *testing.T) {
 		},
 	}, pppRes)
 
-	pppRes = FilterPotentialPricePoints(ppath, pppsFail)
+	pppRes = FilterPotentialPricePoints([]*PricePaths{ppath}, pppsFail)
 	assert.Nil(t, pppRes)
 }

--- a/processor_test.go
+++ b/processor_test.go
@@ -116,7 +116,7 @@ func (suite *ProcessorSuite) TestProcessorProcessSuccess() {
 	}
 	pp := newPotentialPricePoint("binance", pair)
 	pp2 := newPotentialPricePoint("binance", pair)
-	agg := aggregator.NewIndirectMedian(pair)
+	agg := aggregator.NewMedian(1000)
 
 	resp := &query.HTTPResponse{
 		Body: []byte(`{"price":"1"}`),


### PR DESCRIPTION
- Refactor `Median` aggregator to handle more than one pair per instance, as discussed here: https://github.com/makerdao/gofer/pull/13#discussion_r424370693
- Remove `Trade` and `IndirectMedian` aggregators and replaced them with more specific functions
- Makefile: Add `-tags` to `go test` to be able to omit test files that aren't ready yet. Usage: add `// +build !all` at the top of `*_test.go` files you don't want to run on `make test/bench/cover` (more info: https://stackoverflow.com/a/24036237)
- Makefile: Only process files that have been added to GIT index when `make test/add-license`