### PR TITLE
Add pair field to bitfinex Exchange.Config

### DIFF
--- a/exchange/bitfinex.go
+++ b/exchange/bitfinex.go
@@ -40,7 +40,11 @@ func (b *Bitfinex) Call(pool query.WorkerPool, pp *model.PotentialPricePoint) (*
 		return nil, err
 	}
 
-	pair := strings.ToUpper(pp.Pair.Base + pp.Pair.Quote)
+	pair, ok := pp.Exchange.Config["pair"]
+	if !ok || pair == "" {
+		pair = strings.ToUpper(pp.Pair.Base + pp.Pair.Quote)
+	}
+
 	req := &query.HTTPRequest{
 		URL: fmt.Sprintf(bitfinexURL, pair),
 	}


### PR DESCRIPTION
This is because Bitfinex doesn't map asset names 1:1, e.g. USDT in BTC/USDT is called BTCUSD on Bitfinex.