### PR TITLE
Refactor setz aggregator config format

### DIFF
--- a/aggregator/pricemodelparser.go
+++ b/aggregator/pricemodelparser.go
@@ -16,38 +16,9 @@
 package aggregator
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 )
-
-func (o *PriceOp) UnmarshalJSON(b []byte) error {
-	var s string
-	if err := json.Unmarshal(b, &s); err != nil {
-		return err
-	}
-	switch strings.ToLower(s) {
-	case "*":
-		fallthrough
-	case "multiply":
-		*o = MULTIPLY
-	case "/":
-		fallthrough
-	case "divide":
-		*o = DIVIDE
-	case "":
-		fallthrough
-	case "noop":
-		*o = NOOP
-	default:
-		return fmt.Errorf("price op '%s' not supported", s)
-	}
-	return nil
-}
-
-func (o PriceOp) MarshalJSON() ([]byte, error) {
-	return json.Marshal(o.String())
-}
 
 func (p *Pair) UnmarshalText(text []byte) error {
 	s := string(text)

--- a/aggregator/pricemodelparser_test.go
+++ b/aggregator/pricemodelparser_test.go
@@ -29,19 +29,15 @@ func TestPriceModelMapParse(t *testing.T) {
     "b/c": {
       "method": "median",
       "sources": [
-        { "exchange": "e-a", "pair": "b/c" },
-        { "exchange": "e-b", "pair": "b/c" }
+        [{"origin": "e-a", "pair": "b/c"}],
+        [{"origin": "e-b", "pair": "b/c"}]
       ]
     },
     "a/c": {
       "method": "median",
       "sources": [
-        { "exchange": "e-a", "pair": "a/c" },
-        { "exchange": "e-a",
-          "pair": "a/b",
-          "op": "multiply",
-          "ref": { "pair": "b/c" }
-        }
+        [{"origin": "e-a", "pair": "a/c"}],
+        [{"origin": "e-a", "pair": "a/b"}, {"origin": ".", "pair": "b/c"}]
       ]
     }
   }`)
@@ -53,16 +49,19 @@ func TestPriceModelMapParse(t *testing.T) {
 	bcPriceModel := pmm[Pair{*model.NewPair("b", "c")}]
 	assert.NotNil(t, bcPriceModel)
 	assert.Equal(t, "median", bcPriceModel.Method)
-	assert.ElementsMatch(t, []*PriceRef{
-		{ExchangeName: "e-a", Pair: &Pair{*model.NewPair("b", "c")}},
-		{ExchangeName: "e-b", Pair: &Pair{*model.NewPair("b", "c")}},
+	assert.ElementsMatch(t, []PriceRefPath{
+		{{Origin: "e-a", Pair: Pair{*model.NewPair("b", "c")}}},
+		{{Origin: "e-b", Pair: Pair{*model.NewPair("b", "c")}}},
 	}, bcPriceModel.Sources)
 
 	acPriceModel := pmm[Pair{*model.NewPair("a", "c")}]
 	assert.NotNil(t, acPriceModel)
 	assert.Equal(t, "median", acPriceModel.Method)
-	assert.ElementsMatch(t, []*PriceRef{
-		{ExchangeName: "e-a", Pair: &Pair{*model.NewPair("b", "c")}},
-		{ExchangeName: "e-b", Pair: &Pair{*model.NewPair("b", "c")}},
-	}, bcPriceModel.Sources)
+	assert.ElementsMatch(t, []PriceRefPath{
+		{{Origin: "e-a", Pair: Pair{*model.NewPair("a", "c")}}},
+		{
+			{Origin: "e-a", Pair: Pair{*model.NewPair("a", "b")}},
+			{Origin: ".", Pair: Pair{*model.NewPair("b", "c")}},
+		},
+	}, acPriceModel.Sources)
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -64,13 +64,7 @@ func TestPathWithSetzerPatherAndMedianIntegration(t *testing.T) {
 
 	sources := []*model.PotentialPricePoint{}
 
-	//newPathAggregator := func(ppaths []*model.PricePath) aggregator.Aggregator {
-	//	return aggregator.NewPath(ppaths, aggregator.NewMedian(nil, 1000))
-	//}
 	agg := aggregator.NewPath(aggregator.NewSetzer(), sources, aggregator.NewMedian(nil, 1000))
-
-	// Get relevant price paths to pass to aggregator, using setzer pathing
-	//setzerPather := pather.NewSetzer()
 
 	processor := &mock.Processor{
 		Returns: pas,

--- a/processor.go
+++ b/processor.go
@@ -74,9 +74,9 @@ func (p *Processor) Process(pairs []*model.Pair, agg aggregator.Aggregator) (agg
 	for _, pp := range agg.GetSources(pairs) {
 		res, err := p.ProcessOne(pp)
 		if err != nil {
-			// TODO: ignore exchange errors here so we don't fail all prair requests
-			// because of one bad exchange reply
-			return nil, err
+			// TODO: log exchange errors here so failures are traceable but does't fail
+			// everything because of a single bad exchange reply
+			continue
 		}
 		agg.Ingest(res)
 	}

--- a/testdata/integration-config-1.json
+++ b/testdata/integration-config-1.json
@@ -3,28 +3,28 @@
   "aggregator": {
     "name": "setzer",
     "parameters": {
-      "exchanges": {
-        "e-c": { "a": "1" }
+      "origins": {
+        "e-c": {"a": "1"}
       },
       "pricemodels": {
         "B/C": {
           "method": "median",
           "sources": [
-            {"exchange": "e-a", "pair": "B/C" },
-            {"exchange": "e-b", "pair": "B/C" }
+            [{"origin": "e-a", "pair": "B/C"}],
+            [{"origin": "e-b", "pair": "B/C"}]
           ]
         },
         "A/C": {
           "method": "median",
           "sources": [
-            {"exchange": "e-c", "pair": "A/C" },
-            {"exchange": "e-d", "pair": "A/B", "op": "*", "ref": { "pair": "B/C" } }
+            [{"origin": "e-c", "pair": "A/C"}],
+            [{"origin": "e-d", "pair": "A/B"}, {"origin": ".", "pair": "B/C"}]
           ]
         },
         "D/E": {
           "method": "median",
           "sources": [
-            {"exchange": "e-e", "pair": "D/B", "op": "/", "ref": { "exchange": "e-f", "pair": "E/B" } }
+            [{"origin": "e-e", "pair": "D/B"}, {"origin": "e-f", "pair": "E/B"}]
           ]
         }
       }


### PR DESCRIPTION
Refactored `Setz` aggregator config according to [rev 6 JSON](https://www.notion.so/makerdao/Jul-3-Gofer-Aggregator-1c68b2d152b04633aaf3ae9c654f678f#9b802b58271947c0b8a1b7c02f7e6bb2). Including `minSourceSuccess` price model property which indicates the minimum amount of sources that have to be available for an aggregation to be successful.

Still left to-do is the `origins` map which doesn't allow multiple configs for the same exchange yet.