### PR TITLE
Create gofer exchange implementation for ddex [ch4860]

### DIFF
--- a/exchange/ddex.go
+++ b/exchange/ddex.go
@@ -1,0 +1,110 @@
+//  Copyright (C) 2020 Maker Ecosystem Growth Holdings, INC.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as
+//  published by the Free Software Foundation, either version 3 of the
+//  License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package exchange
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/makerdao/gofer/model"
+	"github.com/makerdao/gofer/query"
+	"strconv"
+	"time"
+)
+
+// Ddex URL
+const ddexURL = "https://api.ddex.io/v4/markets/%s/orderbook?level=1"
+
+type ddexResponse struct {
+	Desc string `json:"desc"`
+	Data struct {
+		Orderbook struct {
+			Bids []struct {
+				Price  string `json:"price"`
+				Amount string `json:"amount"`
+			} `json:"bids"`
+			Asks []struct {
+				Price  string `json:"price"`
+				Amount string `json:"amount"`
+			} `json:"asks"`
+		} `json:"orderbook"`
+	} `json:"data"`
+}
+
+// Ddex exchange handler
+type Ddex struct{}
+
+// LocalPairName implementation
+func (c *Ddex) LocalPairName(pair *model.Pair) string {
+	return fmt.Sprintf("%s-%s", pair.Base, pair.Quote)
+}
+
+// GetURL implementation
+func (c *Ddex) GetURL(pp *model.PotentialPricePoint) string {
+	return fmt.Sprintf(ddexURL, c.LocalPairName(pp.Pair))
+}
+
+// Call implementation
+func (c *Ddex) Call(pool query.WorkerPool, pp *model.PotentialPricePoint) (*model.PricePoint, error) {
+	if pool == nil {
+		return nil, errNoPoolPassed
+	}
+	err := model.ValidatePotentialPricePoint(pp)
+	if err != nil {
+		return nil, err
+	}
+
+	req := &query.HTTPRequest{
+		URL: c.GetURL(pp),
+	}
+
+	// make query
+	res := pool.Query(req)
+	if res == nil {
+		return nil, errEmptyExchangeResponse
+	}
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	// parsing JSON
+	var resp ddexResponse
+	err = json.Unmarshal(res.Body, &resp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ddex response: %w", err)
+	}
+	// Check if response is successful
+	if resp.Desc != "success" || len(resp.Data.Orderbook.Asks) != 1 || 1 != len(resp.Data.Orderbook.Bids) {
+		return nil, fmt.Errorf("response returned from ddex exchange is invalid %s", res.Body)
+	}
+	// Parsing ask from string
+	ask, err := strconv.ParseFloat(resp.Data.Orderbook.Asks[0].Price, 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ask from ddex exchange %s", res.Body)
+	}
+	// Parsing bid from string
+	bid, err := strconv.ParseFloat(resp.Data.Orderbook.Bids[0].Price, 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse bid from ddex exchange %s", res.Body)
+	}
+	// building PricePoint
+	return &model.PricePoint{
+		Exchange:  pp.Exchange,
+		Pair:      pp.Pair,
+		Ask:       ask,
+		Bid:       bid,
+		Price:     bid,
+		Timestamp: time.Now().Unix(),
+	}, nil
+}

--- a/exchange/ddex_test.go
+++ b/exchange/ddex_test.go
@@ -1,0 +1,228 @@
+//  Copyright (C) 2020 Maker Ecosystem Growth Holdings, INC.
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as
+//  published by the Free Software Foundation, either version 3 of the
+//  License, or (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package exchange
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/makerdao/gofer/model"
+	"github.com/makerdao/gofer/query"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// Define the suite, and absorb the built-in basic suite
+// functionality from testify - including a T() method which
+// returns the current testing context
+type DdexSuite struct {
+	suite.Suite
+	pool     query.WorkerPool
+	exchange Handler
+}
+
+// Setup exchange
+func (suite *DdexSuite) SetupSuite() {
+	suite.exchange = &Ddex{}
+}
+
+func (suite *DdexSuite) TearDownTest() {
+	// cleanup created pool from prev test
+	if suite.pool != nil {
+		suite.pool = nil
+	}
+}
+
+func (suite *DdexSuite) TestLocalPair() {
+	suite.EqualValues("BTC-ETH", suite.exchange.LocalPairName(model.NewPair("BTC", "ETH")))
+	suite.NotEqual("BTC-USDC", suite.exchange.LocalPairName(model.NewPair("BTC", "USD")))
+}
+
+func (suite *DdexSuite) TestFailOnWrongInput() {
+	// no pool
+	_, err := suite.exchange.Call(nil, nil)
+	suite.Equal(errNoPoolPassed, err)
+
+	// empty pp
+	_, err = suite.exchange.Call(newMockWorkerPool(nil), nil)
+	suite.Error(err)
+
+	// wrong pp
+	_, err = suite.exchange.Call(newMockWorkerPool(nil), &model.PotentialPricePoint{})
+	suite.Error(err)
+
+	pp := newPotentialPricePoint("ddex", "BTC", "ETH")
+	// nil as response
+	_, err = suite.exchange.Call(newMockWorkerPool(nil), pp)
+	suite.Equal(errEmptyExchangeResponse, err)
+
+	// error in response
+	ourErr := fmt.Errorf("error")
+	resp := &query.HTTPResponse{
+		Error: ourErr,
+	}
+	_, err = suite.exchange.Call(newMockWorkerPool(resp), pp)
+	suite.Equal(ourErr, err)
+
+	// Error unmarshal
+	resp = &query.HTTPResponse{
+		Body: []byte(""),
+	}
+	_, err = suite.exchange.Call(newMockWorkerPool(resp), pp)
+	suite.Error(err)
+
+	for n, r := range [][]byte{
+		// invalid desc
+		[]byte(`{
+		   "status":0,
+		   "desc":"err",
+		   "template":"",
+		   "params":null,
+		   "data":{
+			  "orderbook":{
+				 "sequence":143661147,
+				 "marketId":"WBTC-USDT",
+				 "bids":[
+					{
+					   "price":"11691.6",
+					   "amount":"0.4173"
+					}
+				 ],
+				 "asks":[
+					{
+					   "price":"11719.8",
+					   "amount":"0.3709"
+					}
+				 ]
+			  }
+		   }
+		}`),
+		// invalid ask price
+		[]byte(`{
+		   "status":0,
+		   "desc":"success",
+		   "template":"",
+		   "params":null,
+		   "data":{
+			  "orderbook":{
+				 "sequence":143661147,
+				 "marketId":"WBTC-USDT",
+				 "bids":[
+					{
+					   "price":"11691.6",
+					   "amount":"0.4173"
+					}
+				 ],
+				 "asks":[
+					{
+					   "price":"err",
+					   "amount":"0.3709"
+					}
+				 ]
+			  }
+		   }
+		}`),
+		// invalid bid price
+		[]byte(`{
+		   "status":0,
+		   "desc":"success",
+		   "template":"",
+		   "params":null,
+		   "data":{
+			  "orderbook":{
+				 "sequence":143661147,
+				 "marketId":"WBTC-USDT",
+				 "bids":[
+					{
+					   "price":"err",
+					   "amount":"0.4173"
+					}
+				 ],
+				 "asks":[
+					{
+					   "price":"11719.8",
+					   "amount":"0.3709"
+					}
+				 ]
+			  }
+		   }
+		}`),
+		// empty order book
+		[]byte(`{
+		   "status":0,
+		   "desc":"success",
+		   "template":"",
+		   "params":null,
+		   "data":{
+			  "orderbook":{
+				 "sequence":143661147,
+				 "marketId":"WBTC-USDT",
+				 "bids":[],
+				 "asks":[]
+			  }
+		   }
+		}`),
+	} {
+		suite.T().Run(fmt.Sprintf("Case-%d", n+1), func(t *testing.T) {
+			resp = &query.HTTPResponse{Body: r}
+			_, err = suite.exchange.Call(newMockWorkerPool(resp), pp)
+			suite.Error(err)
+		})
+	}
+}
+
+func (suite *DdexSuite) TestSuccessResponse() {
+	pp := newPotentialPricePoint("ddex", "BTC", "ETH")
+	resp := &query.HTTPResponse{
+		Body: []byte(`{
+		   "status":0,
+		   "desc":"success",
+		   "template":"",
+		   "params":null,
+		   "data":{
+			  "orderbook":{
+				 "sequence":143661147,
+				 "marketId":"WBTC-USDT",
+				 "bids":[
+					{
+					   "price":"100.5",
+					   "amount":"0.4173"
+					}
+				 ],
+				 "asks":[
+					{
+					   "price":"101.6",
+					   "amount":"0.3709"
+					}
+				 ]
+			  }
+		   }
+		}`),
+	}
+	point, err := suite.exchange.Call(newMockWorkerPool(resp), pp)
+	suite.NoError(err)
+	suite.Equal(pp.Exchange, point.Exchange)
+	suite.Equal(pp.Pair, point.Pair)
+	suite.Equal(101.6, point.Ask)
+	suite.Equal(100.5, point.Bid)
+	suite.Equal(100.5, point.Price)
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestDdexSuite(t *testing.T) {
+	suite.Run(t, new(DdexSuite))
+}

--- a/exchange/exchanges.go
+++ b/exchange/exchanges.go
@@ -45,6 +45,7 @@ var exchangeList = map[string]Handler{
 	"bittrex":     &BitTrex{},
 	"coinbase":    &Coinbase{},
 	"coinbasepro": &CoinbasePro{},
+	"ddex":        &Ddex{},
 	"fx":          &Fx{},
 	"gateio":      &Gateio{},
 	"gemini":      &Gemini{},


### PR DESCRIPTION
This exchange has a completely broken API so I had to use a different endpoint than in setzer.

Only that endpoints returns the correct data:
https://api.ddex.io/v4/markets/WBTC-USDT/orderbook?level=1
https://api.ddex.io/v4/markets/WBTC-USDT/candles

Broken endpoins are:
https://api.ddex.io/v4/markets/WBTC-USDT - endpoint used in setzer, always returns 0 as a price
https://api.ddex.io/v4/markets/WBTC-USDT/ticker - returns very outdated data

