### PR TITLE
Add assertion to test exchange config from JSON

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -147,6 +147,15 @@ func TestSetzAggregatorIntegration(t *testing.T) {
 		{Exchange: &model.Exchange{Name: "e-b"}, Pair: model.NewPair("b", "c")},
 	}, ppps)
 
+	ppps = gofer.aggregator.GetSources([]*model.Pair{model.NewPair("A", "C")})
+
+	assert.ElementsMatch(t, []*model.PotentialPricePoint{
+		{Exchange: &model.Exchange{Name: "e-d"}, Pair: model.NewPair("a", "b")},
+		{Exchange: &model.Exchange{Name: "e-a"}, Pair: model.NewPair("b", "c")},
+		{Exchange: &model.Exchange{Name: "e-b"}, Pair: model.NewPair("b", "c")},
+		{Exchange: &model.Exchange{Name: "e-c", Config: map[string]string{"a": "1"}}, Pair: model.NewPair("a", "c")},
+	}, ppps)
+
 	for i := 0; i < 1; i++ {
 		res, err := gofer.Prices(
 			model.NewPair("A", "C"),


### PR DESCRIPTION
This PR is mostly to demonstrate that an implementation of being able to [globally configure exchanges (story)](https://app.clubhouse.io/maker/story/5149/add-exchange-configuration-parser) through JSON may already exist.