### PR TITLE
Add test for PriceModelMap.ResolveRef [ch4586]

### DIFF
--- a/aggregator/pricemodel.go
+++ b/aggregator/pricemodel.go
@@ -283,7 +283,10 @@ func (pmm PriceModelMap) ResolveRef(cache CacheGetter, pr PriceRef) (*model.Pric
 
 	successes := len(result.Prices)
 	if successes == 0 || successes < m.MinSources {
-		return nil, fmt.Errorf("minimum amount of sources not met for '%s' in price model", pr.Pair.String())
+		return nil, fmt.Errorf(
+			"minimum number of sources not met for '%s' in price model: %d < %d",
+			pr.Pair.String(), successes, m.MinSources,
+		)
 	}
 
 	method, ok := PriceModelMethods[m.Method]


### PR DESCRIPTION
Mainly testing that `PriceModel.MinSources` works as intended, i.e. `PriceModelMap.ResolveRef()` returning an error if requested `Pair` result doesn't  contain at least as many sources (in `PriceAggregate.Prices`) as the number set in `MinSources`.