### PR TITLE
Remove setter to not allow for internal state changes in Gofer after initialisation

### DIFF
--- a/pkg/gofer/gofer.go
+++ b/pkg/gofer/gofer.go
@@ -34,11 +34,6 @@ func NewGofer(agg aggregator.Aggregator, processor AggregateProcessor) *Gofer {
 	}
 }
 
-// SetProcessor sets new `AggregateProcessor` to gofer instance
-func (g *Gofer) SetProcessor(processor AggregateProcessor) {
-	g.processor = processor
-}
-
 // Price returns a map of aggregated prices according
 func (g *Gofer) Prices(pairs ...*model.Pair) (map[model.Pair]*model.PriceAggregate, error) {
 	if _, err := g.processor.Process(pairs, g.aggregator); err != nil {

--- a/pkg/gofer/processor.go
+++ b/pkg/gofer/processor.go
@@ -35,8 +35,7 @@ func NewProcessor(set *exchange.Set) *Processor {
 	}
 }
 
-// ProcessOne processes `PotentialPricePoint` and fetches new price for it
-func (p *Processor) ProcessOne(pp *model.PotentialPricePoint) (*model.PriceAggregate, error) {
+func (p *Processor) processOne(pp *model.PotentialPricePoint) (*model.PriceAggregate, error) {
 	if err := model.ValidatePotentialPricePoint(pp); err != nil {
 		return nil, err
 	}
@@ -59,7 +58,7 @@ func (p *Processor) Process(pairs []*model.Pair, agg aggregator.Aggregator) (agg
 		return nil, fmt.Errorf("no working agregator passed to processor")
 	}
 	for _, pp := range agg.GetSources(pairs) {
-		res, err := p.ProcessOne(pp)
+		res, err := p.processOne(pp)
 		if err != nil {
 			// TODO: log exchange errors here so failures are traceable but does't fail
 			// everything because of a single bad exchange reply

--- a/pkg/gofer/processor_test.go
+++ b/pkg/gofer/processor_test.go
@@ -53,13 +53,13 @@ func (suite *ProcessorSuite) TestNegativeProcessOne() {
 	}
 
 	p := NewProcessor(set)
-	resp, err := p.ProcessOne(&model.PotentialPricePoint{})
+	resp, err := p.processOne(&model.PotentialPricePoint{})
 	suite.Nil(resp)
 	suite.Error(err)
 
 	wrongPp := newPotentialPricePoint("nonexisting", pair)
 	p = NewProcessor(set)
-	resp, err = p.ProcessOne(wrongPp)
+	resp, err = p.processOne(wrongPp)
 	suite.Nil(resp)
 	suite.Error(err)
 }
@@ -80,7 +80,7 @@ func (suite *ProcessorSuite) TestProcessorProcessOneSuccess() {
 	}
 	wp.MockResp(resp)
 	p := NewProcessor(set)
-	point, err := p.ProcessOne(pp)
+	point, err := p.processOne(pp)
 
 	suite.NoError(err)
 	suite.EqualValues(pp.Pair, point.Pair)


### PR DESCRIPTION
Also, we do not need to expose `processOne`.

And actually, I think Gofer IS a processor and we should merge it into one service and limit the library API surface.