### PR TITLE
Proposal: remove potential price point

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -133,7 +133,7 @@ linters-settings:
     check-exported: false
   whitespace:
     multi-if: true   # Enforces newlines (or comments) after every multi-line if statement
-    multi-func: true # Enforces newlines (or comments) after every multi-line function signature
+    multi-func: false # Enforces newlines (or comments) after every multi-line function signature
 
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.

--- a/internal/mock/aggregator/aggregator.go
+++ b/internal/mock/aggregator/aggregator.go
@@ -40,15 +40,15 @@ func (mr *Aggregator) GetSources(pairs ...*model.Pair) []*model.PricePoint {
 			pairs = append(pairs, p.Clone())
 		}
 	}
-	ppps := make(map[string]*model.PricePoint)
+	pps := make(map[string]*model.PricePoint)
 	for _, p := range pairs {
-		for _, ppp := range mr.Sources[*p] {
-			ppps[ppp.String()] = ppp
+		for _, pp := range mr.Sources[*p] {
+			pps[pp.String()] = pp
 		}
 	}
 	var sources []*model.PricePoint
-	for _, ppp := range ppps {
-		sources = append(sources, ppp)
+	for _, pp := range pps {
+		sources = append(sources, pp)
 	}
 	return sources
 }

--- a/internal/mock/aggregator/aggregator.go
+++ b/internal/mock/aggregator/aggregator.go
@@ -21,7 +21,7 @@ import (
 
 type Aggregator struct {
 	Returns map[model.Pair]*model.PriceAggregate
-	Sources map[model.Pair][]*model.PotentialPricePoint
+	Sources map[model.Pair][]*model.PricePoint
 }
 
 func (mr *Aggregator) Ingest(pa *model.PriceAggregate) {
@@ -34,19 +34,19 @@ func (mr *Aggregator) Aggregate(pair *model.Pair) *model.PriceAggregate {
 	return mr.Returns[*pair]
 }
 
-func (mr *Aggregator) GetSources(pairs ...*model.Pair) []*model.PotentialPricePoint {
+func (mr *Aggregator) GetSources(pairs ...*model.Pair) []*model.PricePoint {
 	if pairs == nil {
 		for p := range mr.Sources {
 			pairs = append(pairs, p.Clone())
 		}
 	}
-	ppps := make(map[string]*model.PotentialPricePoint)
+	ppps := make(map[string]*model.PricePoint)
 	for _, p := range pairs {
 		for _, ppp := range mr.Sources[*p] {
 			ppps[ppp.String()] = ppp
 		}
 	}
-	var sources []*model.PotentialPricePoint
+	var sources []*model.PricePoint
 	for _, ppp := range ppps {
 		sources = append(sources, ppp)
 	}

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -28,8 +28,8 @@ type Aggregator interface {
 	Ingest(*model.PriceAggregate)
 	// Calculate asset pair aggregate returning nil if pair not available
 	Aggregate(*model.Pair) *model.PriceAggregate
-	// GetSources returns PotentialPricePoints
-	GetSources(...*model.Pair) []*model.PotentialPricePoint
+	// GetSources returns PricePoints
+	GetSources(...*model.Pair) []*model.PricePoint
 }
 
 type AggregatorParams struct {

--- a/pkg/aggregator/median.go
+++ b/pkg/aggregator/median.go
@@ -32,11 +32,11 @@ type traceAggregate struct {
 type Median struct {
 	timeWindow int64
 	aggregates map[model.Pair]*traceAggregate
-	sources    []*model.PotentialPricePoint
+	sources    []*model.PricePoint
 }
 
 // NewMedian returns a new instance of Medain with a time window in milliseconds
-func NewMedian(sources []*model.PotentialPricePoint, timeWindow int64) *Median {
+func NewMedian(sources []*model.PricePoint, timeWindow int64) *Median {
 	return &Median{
 		timeWindow: timeWindow,
 		aggregates: make(map[model.Pair]*traceAggregate),
@@ -51,10 +51,10 @@ type Source struct {
 	Parameters map[string]string `json:"parameters"`
 }
 
-func ToPotentialPricePoints(sources []Source) []*model.PotentialPricePoint {
-	var ppps []*model.PotentialPricePoint
+func ToPricePoints(sources []Source) []*model.PricePoint {
+	var ppps []*model.PricePoint
 	for _, s := range sources {
-		ppps = append(ppps, &model.PotentialPricePoint{
+		ppps = append(ppps, &model.PricePoint{
 			Pair:     model.NewPair(s.Base, s.Quote),
 			Exchange: &model.Exchange{Name: s.Exchange, Config: s.Parameters},
 		})
@@ -75,7 +75,7 @@ func NewMedianFromJSON(raw []byte) (Aggregator, error) {
 		return nil, fmt.Errorf("couldn't parse median aggregator parameters: %w", err)
 	}
 
-	return NewMedian(ToPotentialPricePoints(params.Sources), params.TimeWindow), nil
+	return NewMedian(ToPricePoints(params.Sources), params.TimeWindow), nil
 }
 
 func newTraceAggregate(pair *model.Pair) *traceAggregate {
@@ -163,13 +163,13 @@ func (r *Median) Aggregate(pair *model.Pair) *model.PriceAggregate {
 	return trace.Clone()
 }
 
-func (r *Median) GetSources(pairs ...*model.Pair) []*model.PotentialPricePoint {
+func (r *Median) GetSources(pairs ...*model.Pair) []*model.PricePoint {
 	pairMap := make(map[model.Pair]bool)
 	for _, pair := range pairs {
 		pairMap[*pair] = true
 	}
 
-	var ppps []*model.PotentialPricePoint
+	var ppps []*model.PricePoint
 	for _, ppp := range r.sources {
 		if _, ok := pairMap[*ppp.Pair]; ok {
 			ppps = append(ppps, ppp)

--- a/pkg/aggregator/median.go
+++ b/pkg/aggregator/median.go
@@ -52,14 +52,14 @@ type Source struct {
 }
 
 func ToPricePoints(sources []Source) []*model.PricePoint {
-	var ppps []*model.PricePoint
+	var pps []*model.PricePoint
 	for _, s := range sources {
-		ppps = append(ppps, &model.PricePoint{
+		pps = append(pps, &model.PricePoint{
 			Pair:     model.NewPair(s.Base, s.Quote),
 			Exchange: &model.Exchange{Name: s.Exchange, Config: s.Parameters},
 		})
 	}
-	return ppps
+	return pps
 }
 
 type MedianParams struct {
@@ -169,11 +169,11 @@ func (r *Median) GetSources(pairs ...*model.Pair) []*model.PricePoint {
 		pairMap[*pair] = true
 	}
 
-	var ppps []*model.PricePoint
-	for _, ppp := range r.sources {
-		if _, ok := pairMap[*ppp.Pair]; ok {
-			ppps = append(ppps, ppp)
+	var pps []*model.PricePoint
+	for _, pp := range r.sources {
+		if _, ok := pairMap[*pp.Pair]; ok {
+			pps = append(pps, pp)
 		}
 	}
-	return ppps
+	return pps
 }

--- a/pkg/aggregator/median_test.go
+++ b/pkg/aggregator/median_test.go
@@ -104,9 +104,9 @@ func TestMedian(t *testing.T) {
 	res = median([]float64{})
 	assert.Equal(t, 0.0, res)
 
-	res = median([]float64{4,2,3,4,5})
+	res = median([]float64{4, 2, 3, 4, 5})
 	assert.Equal(t, 4.0, res)
 
-	res = median([]float64{5,2,10,19})
+	res = median([]float64{5, 2, 10, 19})
 	assert.Equal(t, 7.5, res)
 }

--- a/pkg/aggregator/path.go
+++ b/pkg/aggregator/path.go
@@ -43,7 +43,7 @@ func (ip *IdentityPather) Path(target *model.Pair) []*model.PricePath {
 type Path struct {
 	pather           Pather
 	directAggregator Aggregator
-	sources          []*model.PotentialPricePoint
+	sources          []*model.PricePoint
 }
 
 func paths(pather Pather, pairs []*model.Pair) []*model.PricePath {
@@ -63,7 +63,7 @@ func paths(pather Pather, pairs []*model.Pair) []*model.PricePath {
 
 // NewPath returns a new instance of `Path` that uses the given price paths to
 // aggregate indirect pairs and an aggregator to merge direct pairs.
-func NewPath(pather Pather, sources []*model.PotentialPricePoint, directAggregator Aggregator) *Path {
+func NewPath(pather Pather, sources []*model.PricePoint, directAggregator Aggregator) *Path {
 	return &Path{
 		pather:           pather, // *model.NewPricePathMap(ppaths),
 		directAggregator: directAggregator,
@@ -71,7 +71,7 @@ func NewPath(pather Pather, sources []*model.PotentialPricePoint, directAggregat
 	}
 }
 
-func NewPathWithPathMap(ppaths []*model.PricePath, sources []*model.PotentialPricePoint, directAggregator Aggregator) *Path {
+func NewPathWithPathMap(ppaths []*model.PricePath, sources []*model.PricePoint, directAggregator Aggregator) *Path {
 	pather := &IdentityPather{PricePathMap: model.NewPricePathMap(ppaths)}
 	return NewPath(
 		pather,
@@ -112,7 +112,7 @@ func NewPathFromJSON(raw []byte) (Aggregator, error) {
 		return nil, err
 	}
 
-	ppps := ToPotentialPricePoints(params.Sources)
+	ppps := ToPricePoints(params.Sources)
 
 	return NewPathWithPathMap(ToModelPricePaths(params.PricePaths), ppps, subAgg), nil
 }
@@ -192,8 +192,8 @@ func (r *Path) Aggregate(pair *model.Pair) *model.PriceAggregate {
 	)
 }
 
-func (r *Path) GetSources(pairs ...*model.Pair) []*model.PotentialPricePoint {
+func (r *Path) GetSources(pairs ...*model.Pair) []*model.PricePoint {
 	ppaths := paths(r.pather, pairs)
-	_, ppps := FilterPotentialPricePoints(ppaths, r.sources)
+	_, ppps := FilterPricePoints(ppaths, r.sources)
 	return ppps
 }

--- a/pkg/aggregator/path.go
+++ b/pkg/aggregator/path.go
@@ -112,9 +112,9 @@ func NewPathFromJSON(raw []byte) (Aggregator, error) {
 		return nil, err
 	}
 
-	ppps := ToPricePoints(params.Sources)
+	pps := ToPricePoints(params.Sources)
 
-	return NewPathWithPathMap(ToModelPricePaths(params.PricePaths), ppps, subAgg), nil
+	return NewPathWithPathMap(ToModelPricePaths(params.PricePaths), pps, subAgg), nil
 }
 
 // Calculate the final model.trade price of an ordered list of prices
@@ -194,6 +194,6 @@ func (r *Path) Aggregate(pair *model.Pair) *model.PriceAggregate {
 
 func (r *Path) GetSources(pairs ...*model.Pair) []*model.PricePoint {
 	ppaths := paths(r.pather, pairs)
-	_, ppps := FilterPricePoints(ppaths, r.sources)
-	return ppps
+	_, pps := FilterPricePoints(ppaths, r.sources)
+	return pps
 }

--- a/pkg/aggregator/path_test.go
+++ b/pkg/aggregator/path_test.go
@@ -94,13 +94,13 @@ func TestPathAggregator(t *testing.T) {
 		assert.Equal(t, model.NewPair("a", "d"), res.Pair)
 		assert.Equal(t, "path", res.PriceModelName)
 		// Median of trade abd, acd and bad is 1001 * 1002
-		assert.Equal(t, 1001.0 * 1002.0, res.Price)
+		assert.Equal(t, 1001.0*1002.0, res.Price)
 
 		resTradeABD := res.Prices[0]
 		assert.NotNil(t, resTradeABD)
 		assert.Equal(t, model.NewPair("a", "d"), resTradeABD.Pair)
 		assert.Equal(t, "trade", resTradeABD.PriceModelName)
-		assert.Equal(t, 1001.0 * 1002.0, resTradeABD.Price)
+		assert.Equal(t, 1001.0*1002.0, resTradeABD.Price)
 
 		resMedinaAB := resTradeABD.Prices[0]
 		assert.NotNil(t, resMedinaAB)
@@ -120,7 +120,7 @@ func TestPathAggregator(t *testing.T) {
 		assert.NotNil(t, resTradeACD)
 		assert.Equal(t, model.NewPair("a", "d"), resTradeACD.Pair)
 		assert.Equal(t, "trade", resTradeACD.PriceModelName)
-		assert.Equal(t, 1003.0 * 1004.0, resTradeACD.Price)
+		assert.Equal(t, 1003.0*1004.0, resTradeACD.Price)
 
 		resMedinaAC := resTradeACD.Prices[0]
 		assert.NotNil(t, resMedinaAC)
@@ -140,7 +140,7 @@ func TestPathAggregator(t *testing.T) {
 		assert.NotNil(t, resTradeBAD)
 		assert.Equal(t, model.NewPair("a", "d"), resTradeBAD.Pair)
 		assert.Equal(t, "trade", resTradeBAD.PriceModelName)
-		assert.Equal(t, 1002.0 / 2, resTradeBAD.Price)
+		assert.Equal(t, 1002.0/2, resTradeBAD.Price)
 
 		resMedinaBA := resTradeBAD.Prices[0]
 		assert.NotNil(t, resMedinaBA)
@@ -170,12 +170,12 @@ func TestTrade(t *testing.T) {
 	resAE := trade(pasAE)
 	assert.NotNil(t, resAE)
 	assert.Equal(t, model.NewPair("a", "e"), resAE.Pair)
-	assert.Equal(t, 10.0 * 20.0 * 200.0 * 40.0, resAE.Price)
+	assert.Equal(t, 10.0*20.0*200.0*40.0, resAE.Price)
 
 	resCE := trade(pasCE)
 	assert.NotNil(t, resCE)
 	assert.Equal(t, model.NewPair("c", "e"), resCE.Pair)
-	assert.Equal(t, 200.0 / (10.0 * 20.0) * 40.0, resCE.Price)
+	assert.Equal(t, 200.0/(10.0*20.0)*40.0, resCE.Price)
 }
 
 func TestPathResolveMissingPair(t *testing.T) {
@@ -198,7 +198,7 @@ func TestPathResolveMissingPair(t *testing.T) {
 
 	var res *model.PriceAggregate
 
-	res = pathAggregator.resolve(model.PricePath{ model.NewPair("a", "b") })
+	res = pathAggregator.resolve(model.PricePath{model.NewPair("a", "b")})
 	assert.NotNil(t, res)
 	assert.Equal(t, 100.0, res.Price)
 

--- a/pkg/aggregator/pather.go
+++ b/pkg/aggregator/pather.go
@@ -27,12 +27,12 @@ type Pather interface {
 	Path(*model.Pair) []*model.PricePath
 }
 
-// FilterPotentialPricePoints returns the PotentialPricePoints that are required
+// FilterPricePoints returns the PricePoints that are required
 // to complete the PricePaths given and nil if no paths are possible to complete
-// with the given PotentialPricePoints
-func FilterPotentialPricePoints(ppaths []*model.PricePath, ppps []*model.PotentialPricePoint) ([]*model.PricePath, []*model.PotentialPricePoint) {
-	// Group all PotentialPricePoints by pair
-	pppIndex := make(map[model.Pair][]*model.PotentialPricePoint)
+// with the given PricePoints
+func FilterPricePoints(ppaths []*model.PricePath, ppps []*model.PricePoint) ([]*model.PricePath, []*model.PricePoint) {
+	// Group all PricePoints by pair
+	pppIndex := make(map[model.Pair][]*model.PricePoint)
 	for _, ppp := range ppps {
 		pair := *ppp.Pair
 		pppIndex[pair] = append(pppIndex[pair], ppp)
@@ -40,9 +40,9 @@ func FilterPotentialPricePoints(ppaths []*model.PricePath, ppps []*model.Potenti
 
 	var resPricePaths []*model.PricePath
 	pairs := make(map[model.Pair]bool)
-	outer:
+outer:
 	for _, ppath := range ppaths {
-		// Check that each PricePath has all of its Pairs in PotentialPricePoints
+		// Check that each PricePath has all of its Pairs in PricePoints
 		for _, pair := range *ppath {
 			if _, ok := pppIndex[*pair]; !ok {
 				// Continue with next PricePath and don't add pairs to list
@@ -56,8 +56,8 @@ func FilterPotentialPricePoints(ppaths []*model.PricePath, ppps []*model.Potenti
 		resPricePaths = append(resPricePaths, ppath)
 	}
 
-	// Add each uniqe PotentialPricePoint by completed PricePath Pair
-	var resPPP []*model.PotentialPricePoint
+	// Add each uniqe PricePoint by completed PricePath Pair
+	var resPPP []*model.PricePoint
 	for pair := range pairs {
 		resPPP = append(resPPP, pppIndex[pair]...)
 	}

--- a/pkg/aggregator/pather.go
+++ b/pkg/aggregator/pather.go
@@ -30,12 +30,12 @@ type Pather interface {
 // FilterPricePoints returns the PricePoints that are required
 // to complete the PricePaths given and nil if no paths are possible to complete
 // with the given PricePoints
-func FilterPricePoints(ppaths []*model.PricePath, ppps []*model.PricePoint) ([]*model.PricePath, []*model.PricePoint) {
+func FilterPricePoints(ppaths []*model.PricePath, pps []*model.PricePoint) ([]*model.PricePath, []*model.PricePoint) {
 	// Group all PricePoints by pair
-	pppIndex := make(map[model.Pair][]*model.PricePoint)
-	for _, ppp := range ppps {
-		pair := *ppp.Pair
-		pppIndex[pair] = append(pppIndex[pair], ppp)
+	ppIndex := make(map[model.Pair][]*model.PricePoint)
+	for _, pp := range pps {
+		pair := *pp.Pair
+		ppIndex[pair] = append(ppIndex[pair], pp)
 	}
 
 	var resPricePaths []*model.PricePath
@@ -44,7 +44,7 @@ outer:
 	for _, ppath := range ppaths {
 		// Check that each PricePath has all of its Pairs in PricePoints
 		for _, pair := range *ppath {
-			if _, ok := pppIndex[*pair]; !ok {
+			if _, ok := ppIndex[*pair]; !ok {
 				// Continue with next PricePath and don't add pairs to list
 				continue outer
 			}
@@ -59,7 +59,7 @@ outer:
 	// Add each uniqe PricePoint by completed PricePath Pair
 	var resPPP []*model.PricePoint
 	for pair := range pairs {
-		resPPP = append(resPPP, pppIndex[pair]...)
+		resPPP = append(resPPP, ppIndex[pair]...)
 	}
 
 	return resPricePaths, resPPP

--- a/pkg/aggregator/pricemodel.go
+++ b/pkg/aggregator/pricemodel.go
@@ -136,26 +136,26 @@ func (pmm PriceModelMap) getRefSources(pr PriceRef) ([]cacheID, error) {
 	return result, nil
 }
 
-func (pmm PriceModelMap) GetRefSources(exchangeMap map[string]*model.Exchange, refs ...PriceRef) ([]*model.PotentialPricePoint, error) {
+func (pmm PriceModelMap) GetRefSources(exchangeMap map[string]*model.Exchange, refs ...PriceRef) ([]*model.PricePoint, error) {
 	cis := make(map[cacheID]bool)
 	for _, ref := range refs {
 		cs, err := pmm.getRefSources(ref)
 		if err != nil {
-			return nil, err
+			continue
 		}
 		for _, ci := range cs {
 			cis[ci] = true
 		}
 	}
 
-	var result []*model.PotentialPricePoint
+	var result []*model.PricePoint
 
 	for ci := range cis {
 		exchange := exchangeMap[ci.exchangeName]
 		if exchange == nil {
 			exchange = &model.Exchange{Name: ci.exchangeName}
 		}
-		result = append(result, &model.PotentialPricePoint{
+		result = append(result, &model.PricePoint{
 			Pair:     ci.pair.Clone(),
 			Exchange: exchange,
 		})
@@ -163,8 +163,8 @@ func (pmm PriceModelMap) GetRefSources(exchangeMap map[string]*model.Exchange, r
 	return result, nil
 }
 
-// GetSources returns PotentialPricePoints
-func (pmm PriceModelMap) GetSources(exchangeMap map[string]*model.Exchange) ([]*model.PotentialPricePoint, error) {
+// GetSources returns PricePoints
+func (pmm PriceModelMap) GetSources(exchangeMap map[string]*model.Exchange) ([]*model.PricePoint, error) {
 	var refs []PriceRef
 	for pair := range pmm {
 		refs = append(refs, PriceRef{Origin: ".", Pair: pair})

--- a/pkg/aggregator/pricemodel.go
+++ b/pkg/aggregator/pricemodel.go
@@ -136,7 +136,10 @@ func (pmm PriceModelMap) getRefSources(pr PriceRef) ([]cacheID, error) {
 	return result, nil
 }
 
-func (pmm PriceModelMap) GetRefSources(exchangeMap map[string]*model.Exchange, refs ...PriceRef) ([]*model.PricePoint, error) {
+func (pmm PriceModelMap) GetRefSources(
+	exchangeMap map[string]*model.Exchange,
+	refs ...PriceRef,
+) ([]*model.PricePoint, error) {
 	cis := make(map[cacheID]bool)
 	for _, ref := range refs {
 		cs, err := pmm.getRefSources(ref)

--- a/pkg/aggregator/setzer.go
+++ b/pkg/aggregator/setzer.go
@@ -83,7 +83,7 @@ func (a *Setz) Aggregate(pair *model.Pair) *model.PriceAggregate {
 	return pa
 }
 
-func (a *Setz) GetSources(pairs ...*model.Pair) []*model.PotentialPricePoint {
+func (a *Setz) GetSources(pairs ...*model.Pair) []*model.PricePoint {
 	// If given list of pairs is empty use all keys in PriceModelMap as pair list
 	if pairs == nil {
 		for p := range a.pairMap {

--- a/pkg/aggregator/setzer.go
+++ b/pkg/aggregator/setzer.go
@@ -95,12 +95,12 @@ func (a *Setz) GetSources(pairs ...*model.Pair) []*model.PricePoint {
 	for _, p := range pairs {
 		refs = append(refs, PriceRef{Origin: ".", Pair: Pair{*p}})
 	}
-	ppps, err := a.pairMap.GetRefSources(a.exchangeMap, refs...)
+	pps, err := a.pairMap.GetRefSources(a.exchangeMap, refs...)
 	if err != nil {
 		// TODO: refactor Aggregator to return error not just nil
 		log.Println(err)
 		return nil
 	}
 
-	return ppps
+	return pps
 }

--- a/pkg/aggregator/setzer_test.go
+++ b/pkg/aggregator/setzer_test.go
@@ -118,23 +118,23 @@ func TestSetzerAggregator(t *testing.T) {
 	res = randomReduce(setz, model.NewPair("g", "h"), pas)
 	assert.Nil(t, res)
 
-	ppps := setz.GetSources([]*model.Pair{model.NewPair("b", "c")}...)
+	pps := setz.GetSources([]*model.Pair{model.NewPair("b", "c")}...)
 	assert.ElementsMatch(t, []*model.PricePoint{
 		{Exchange: &model.Exchange{Name: "e1"}, Pair: model.NewPair("b", "c")},
 		{Exchange: &model.Exchange{Name: "e2"}, Pair: model.NewPair("b", "c")},
 		{Exchange: &model.Exchange{Name: "e3", Config: map[string]string{"a": "1"}}, Pair: model.NewPair("b", "c")},
-	}, ppps)
+	}, pps)
 
-	ppps = setz.GetSources([]*model.Pair{model.NewPair("a", "c")}...)
+	pps = setz.GetSources([]*model.Pair{model.NewPair("a", "c")}...)
 	assert.ElementsMatch(t, []*model.PricePoint{
 		{Exchange: &model.Exchange{Name: "e1"}, Pair: model.NewPair("b", "c")},
 		{Exchange: &model.Exchange{Name: "e2"}, Pair: model.NewPair("b", "c")},
 		{Exchange: &model.Exchange{Name: "e3", Config: map[string]string{"a": "1"}}, Pair: model.NewPair("b", "c")},
 		{Exchange: &model.Exchange{Name: "e1"}, Pair: model.NewPair("a", "c")},
 		{Exchange: &model.Exchange{Name: "e1"}, Pair: model.NewPair("a", "b")},
-	}, ppps)
+	}, pps)
 
-	ppps = setz.GetSources()
+	pps = setz.GetSources()
 	assert.ElementsMatch(t, []*model.PricePoint{
 		{Exchange: &model.Exchange{Name: "e1"}, Pair: model.NewPair("b", "c")},
 		{Exchange: &model.Exchange{Name: "e2"}, Pair: model.NewPair("b", "c")},
@@ -146,5 +146,5 @@ func TestSetzerAggregator(t *testing.T) {
 		{Exchange: &model.Exchange{Name: "e4"}, Pair: model.NewPair("x", "y")},
 		{Exchange: &model.Exchange{Name: "no"}, Pair: model.NewPair("n", "o")},
 		{Exchange: &model.Exchange{Name: "e1"}, Pair: model.NewPair("g", "h")},
-	}, ppps)
+	}, pps)
 }

--- a/pkg/aggregator/setzer_test.go
+++ b/pkg/aggregator/setzer_test.go
@@ -119,14 +119,14 @@ func TestSetzerAggregator(t *testing.T) {
 	assert.Nil(t, res)
 
 	ppps := setz.GetSources([]*model.Pair{model.NewPair("b", "c")}...)
-	assert.ElementsMatch(t, []*model.PotentialPricePoint{
+	assert.ElementsMatch(t, []*model.PricePoint{
 		{Exchange: &model.Exchange{Name: "e1"}, Pair: model.NewPair("b", "c")},
 		{Exchange: &model.Exchange{Name: "e2"}, Pair: model.NewPair("b", "c")},
 		{Exchange: &model.Exchange{Name: "e3", Config: map[string]string{"a": "1"}}, Pair: model.NewPair("b", "c")},
 	}, ppps)
 
 	ppps = setz.GetSources([]*model.Pair{model.NewPair("a", "c")}...)
-	assert.ElementsMatch(t, []*model.PotentialPricePoint{
+	assert.ElementsMatch(t, []*model.PricePoint{
 		{Exchange: &model.Exchange{Name: "e1"}, Pair: model.NewPair("b", "c")},
 		{Exchange: &model.Exchange{Name: "e2"}, Pair: model.NewPair("b", "c")},
 		{Exchange: &model.Exchange{Name: "e3", Config: map[string]string{"a": "1"}}, Pair: model.NewPair("b", "c")},
@@ -135,7 +135,7 @@ func TestSetzerAggregator(t *testing.T) {
 	}, ppps)
 
 	ppps = setz.GetSources()
-	assert.ElementsMatch(t, []*model.PotentialPricePoint{
+	assert.ElementsMatch(t, []*model.PricePoint{
 		{Exchange: &model.Exchange{Name: "e1"}, Pair: model.NewPair("b", "c")},
 		{Exchange: &model.Exchange{Name: "e2"}, Pair: model.NewPair("b", "c")},
 		{Exchange: &model.Exchange{Name: "e3", Config: map[string]string{"a": "1"}}, Pair: model.NewPair("b", "c")},

--- a/pkg/aggregator/trade.go
+++ b/pkg/aggregator/trade.go
@@ -20,7 +20,7 @@ import (
 )
 
 type Trade struct {
-	ppath model.PricePath
+	ppath     model.PricePath
 	aggregate *model.PriceAggregate
 }
 

--- a/pkg/aggregator/utils_test.go
+++ b/pkg/aggregator/utils_test.go
@@ -60,10 +60,10 @@ func newTestPricePointAggregatePriceOnly(timestamp int64, exchange string, base 
 func newTestPriceAggregate(name string, base string, quote string, price float64, prices ...*model.PriceAggregate) *model.PriceAggregate {
 	return &model.PriceAggregate{
 		PricePoint: &model.PricePoint{
-			Pair:      model.NewPair(base, quote),
-			Price:     price,
+			Pair:  model.NewPair(base, quote),
+			Price: price,
 		},
 		PriceModelName: name,
-		Prices: prices,
+		Prices:         prices,
 	}
 }

--- a/pkg/exchange/binance.go
+++ b/pkg/exchange/binance.go
@@ -56,6 +56,7 @@ func (b *Binance) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (b *Binance) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {

--- a/pkg/exchange/binance.go
+++ b/pkg/exchange/binance.go
@@ -50,9 +50,9 @@ func (b *Binance) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(binanceURL, b.localPairName(pp.Pair))
 }
 
-func (b *Binance) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		b.callOne(ppp)
+func (b *Binance) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		b.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/binance.go
+++ b/pkg/exchange/binance.go
@@ -52,11 +52,11 @@ func (b *Binance) getURL(pp *model.PricePoint) string {
 
 func (b *Binance) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		b.callOne(pp)
+		b.fetchOne(pp)
 	}
 }
 
-func (b *Binance) callOne(pp *model.PricePoint) {
+func (b *Binance) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/binance_test.go
+++ b/pkg/exchange/binance_test.go
@@ -56,20 +56,16 @@ func (suite *BinanceSuite) TestLocalPair() {
 }
 
 func (suite *BinanceSuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("binance", "BTC", "ETH")
+	pp := newPricePoint("binance", "BTC", "ETH")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -78,38 +74,42 @@ func (suite *BinanceSuite) TestFailOnWrongInput() {
 	}
 
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(""),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error convert price to number
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"price":"abcd"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 }
 
 func (suite *BinanceSuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("binance", "BTC", "ETH")
+	pp := newPricePoint("binance", "BTC", "ETH")
 	resp := &query.HTTPResponse{
 		Body: []byte(`{"price":"1"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(1.0, cr[0].PricePoint.Price)
-	suite.Greater(cr[0].PricePoint.Timestamp, int64(0))
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(1.0, pps[0].Price)
+	suite.Greater(pps[0].Timestamp, int64(0))
 }
 
 func (suite *BinanceSuite) TestRealAPICall() {

--- a/pkg/exchange/bitfinex.go
+++ b/pkg/exchange/bitfinex.go
@@ -60,11 +60,11 @@ func (b *Bitfinex) getURL(pp *model.PricePoint) string {
 
 func (b *Bitfinex) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		b.callOne(pp)
+		b.fetchOne(pp)
 	}
 }
 
-func (b *Bitfinex) callOne(pp *model.PricePoint) {
+func (b *Bitfinex) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/bitfinex.go
+++ b/pkg/exchange/bitfinex.go
@@ -58,9 +58,9 @@ func (b *Bitfinex) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(bitfinexURL, pair)
 }
 
-func (b *Bitfinex) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		b.callOne(ppp)
+func (b *Bitfinex) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		b.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/bitfinex.go
+++ b/pkg/exchange/bitfinex.go
@@ -64,6 +64,7 @@ func (b *Bitfinex) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (b *Bitfinex) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {

--- a/pkg/exchange/bitfinex_test.go
+++ b/pkg/exchange/bitfinex_test.go
@@ -57,20 +57,16 @@ func (suite *BitfinexSuite) TestLocalPair() {
 }
 
 func (suite *BitfinexSuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("bitfinex", "BTC", "ETH")
+	pp := newPricePoint("bitfinex", "BTC", "ETH")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -78,38 +74,42 @@ func (suite *BitfinexSuite) TestFailOnWrongInput() {
 		Error: ourErr,
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(""),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`[0,0]`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 }
 
 func (suite *BitfinexSuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("bitfinex", "BTC", "ETH")
+	pp := newPricePoint("bitfinex", "BTC", "ETH")
 	resp := &query.HTTPResponse{
 		Body: []byte(`[1,1,1,1,1,1,1,1]`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(1.0, cr[0].PricePoint.Price)
-	suite.Greater(cr[0].PricePoint.Timestamp, int64(0))
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(1.0, pps[0].Price)
+	suite.Greater(pps[0].Timestamp, int64(0))
 }
 
 func (suite *BitfinexSuite) TestRealAPICall() {

--- a/pkg/exchange/bitstamp.go
+++ b/pkg/exchange/bitstamp.go
@@ -59,6 +59,7 @@ func (b *Bitstamp) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (b *Bitstamp) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {

--- a/pkg/exchange/bitstamp.go
+++ b/pkg/exchange/bitstamp.go
@@ -55,11 +55,11 @@ func (b *Bitstamp) getURL(pp *model.PricePoint) string {
 
 func (b *Bitstamp) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		b.callOne(pp)
+		b.fetchOne(pp)
 	}
 }
 
-func (b *Bitstamp) callOne(pp *model.PricePoint) {
+func (b *Bitstamp) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/bitstamp.go
+++ b/pkg/exchange/bitstamp.go
@@ -53,9 +53,9 @@ func (b *Bitstamp) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(bitstampURL, b.localPairName(pp.Pair))
 }
 
-func (b *Bitstamp) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		b.callOne(ppp)
+func (b *Bitstamp) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		b.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/bitstamp_test.go
+++ b/pkg/exchange/bitstamp_test.go
@@ -56,20 +56,16 @@ func (suite *BitstampSuite) TestLocalPair() {
 }
 
 func (suite *BitstampSuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("bitstamp", "BTC", "ETH")
+	pp := newPricePoint("bitstamp", "BTC", "ETH")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -77,65 +73,72 @@ func (suite *BitstampSuite) TestFailOnWrongInput() {
 		Error: ourErr,
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(""),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"last":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"last":"1","ask":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"last":"1","ask":"1","volume":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"last":"1","ask":"1","volume":"1","bid":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 }
 
 func (suite *BitstampSuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("bitstamp", "BTC", "ETH")
+	pp := newPricePoint("bitstamp", "BTC", "ETH")
 	resp := &query.HTTPResponse{
 		Body: []byte(`{"last":"1","ask":"2","volume":"3","bid":"4","timestamp":"5"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(1.0, cr[0].PricePoint.Price)
-	suite.Equal(2.0, cr[0].PricePoint.Ask)
-	suite.Equal(3.0, cr[0].PricePoint.Volume)
-	suite.Equal(4.0, cr[0].PricePoint.Bid)
-	suite.Equal(int64(5), cr[0].PricePoint.Timestamp)
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(1.0, pps[0].Price)
+	suite.Equal(2.0, pps[0].Ask)
+	suite.Equal(3.0, pps[0].Volume)
+	suite.Equal(4.0, pps[0].Bid)
+	suite.Equal(int64(5), pps[0].Timestamp)
 }
 
 func (suite *BitstampSuite) TestRealAPICall() {

--- a/pkg/exchange/bittrex.go
+++ b/pkg/exchange/bittrex.go
@@ -56,6 +56,7 @@ func (b *BitTrex) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (b *BitTrex) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {

--- a/pkg/exchange/bittrex.go
+++ b/pkg/exchange/bittrex.go
@@ -52,11 +52,11 @@ func (b *BitTrex) getURL(pp *model.PricePoint) string {
 
 func (b *BitTrex) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		b.callOne(pp)
+		b.fetchOne(pp)
 	}
 }
 
-func (b *BitTrex) callOne(pp *model.PricePoint) {
+func (b *BitTrex) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/bittrex.go
+++ b/pkg/exchange/bittrex.go
@@ -50,9 +50,9 @@ func (b *BitTrex) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(bittrexURL, b.localPairName(pp.Pair))
 }
 
-func (b *BitTrex) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		b.callOne(ppp)
+func (b *BitTrex) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		b.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/bittrex_test.go
+++ b/pkg/exchange/bittrex_test.go
@@ -56,20 +56,16 @@ func (suite *BitTrexSuite) TestLocalPair() {
 }
 
 func (suite *BitTrexSuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("bittrex", "BTC", "ETH")
+	pp := newPricePoint("bittrex", "BTC", "ETH")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -77,62 +73,69 @@ func (suite *BitTrexSuite) TestFailOnWrongInput() {
 		Error: ourErr,
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(""),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"success":false}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"success":true,"result":{Last":"abc"}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"success":true,"result":{"Last":1,"Ask":"abc"}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"success":true,"result":{"Last":1,"Ask":1,"Bid":"abc"}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 }
 
 func (suite *BitTrexSuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("bittrex", "BTC", "ETH")
+	pp := newPricePoint("bittrex", "BTC", "ETH")
 	resp := &query.HTTPResponse{
 		Body: []byte(`{"success":true,"result":{"Last":1,"Ask":1,"Bid":1}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(1.0, cr[0].PricePoint.Price)
-	suite.Greater(cr[0].PricePoint.Timestamp, int64(0))
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(1.0, pps[0].Price)
+	suite.Greater(pps[0].Timestamp, int64(0))
 }
 
 func (suite *BitTrexSuite) TestRealAPICall() {

--- a/pkg/exchange/coinbase.go
+++ b/pkg/exchange/coinbase.go
@@ -45,25 +45,21 @@ func (c *Coinbase) localPairName(pair *model.Pair) string {
 	return fmt.Sprintf("%s-%s", strings.ToUpper(pair.Base), strings.ToUpper(pair.Quote))
 }
 
-func (c *Coinbase) getURL(pp *model.PotentialPricePoint) string {
+func (c *Coinbase) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(coinbaseURL, c.localPairName(pp.Pair))
 }
 
-func (c *Coinbase) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
+func (c *Coinbase) Fetch(ppps []*model.PricePoint) {
 	for _, ppp := range ppps {
-		pp, err := c.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
+		c.callOne(ppp)
 	}
-
-	return cr
 }
 
-func (c *Coinbase) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {
-	err := model.ValidatePotentialPricePoint(pp)
+func (c *Coinbase) callOne(pp *model.PricePoint) {
+	err := model.ValidatePricePoint(pp)
 	if err != nil {
-		return nil, err
+		pp.Error = err
+		return
 	}
 
 	req := &query.HTTPRequest{
@@ -73,45 +69,48 @@ func (c *Coinbase) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, er
 	// make query
 	res := c.Pool.Query(req)
 	if res == nil {
-		return nil, errEmptyExchangeResponse
+		pp.Error = errEmptyExchangeResponse
+		return
 	}
 	if res.Error != nil {
-		return nil, res.Error
+		pp.Error = res.Error
+		return
 	}
 	// parsing JSON
 	var resp coinbaseResponse
 	err = json.Unmarshal(res.Body, &resp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse coinbase response: %w", err)
+		pp.Error = fmt.Errorf("failed to parse coinbase response: %w", err)
+		return
 	}
 	// Parsing price from string
 	price, err := strconv.ParseFloat(resp.Price, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse price from coinbase exchange %s", res.Body)
+		pp.Error = fmt.Errorf("failed to parse price from coinbase exchange %s", res.Body)
+		return
 	}
 	// Parsing ask from string
 	ask, err := strconv.ParseFloat(resp.Ask, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse ask from coinbase exchange %s", res.Body)
+		pp.Error = fmt.Errorf("failed to parse ask from coinbase exchange %s", res.Body)
+		return
 	}
 	// Parsing volume from string
 	volume, err := strconv.ParseFloat(resp.Volume, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse volume from coinbase exchange %s", res.Body)
+		pp.Error = fmt.Errorf("failed to parse volume from coinbase exchange %s", res.Body)
+		return
 	}
 	// Parsing bid from string
 	bid, err := strconv.ParseFloat(resp.Bid, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse bid from coinbase exchange %s", res.Body)
+		pp.Error = fmt.Errorf("failed to parse bid from coinbase exchange %s", res.Body)
+		return
 	}
-	// building PricePoint
-	return &model.PricePoint{
-		Exchange:  pp.Exchange,
-		Pair:      pp.Pair,
-		Price:     price,
-		Volume:    volume,
-		Ask:       ask,
-		Bid:       bid,
-		Timestamp: time.Now().Unix(),
-	}, nil
+
+	pp.Price = price
+	pp.Volume = volume
+	pp.Ask = ask
+	pp.Bid = bid
+	pp.Timestamp = time.Now().Unix()
 }

--- a/pkg/exchange/coinbase.go
+++ b/pkg/exchange/coinbase.go
@@ -49,9 +49,9 @@ func (c *Coinbase) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(coinbaseURL, c.localPairName(pp.Pair))
 }
 
-func (c *Coinbase) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		c.callOne(ppp)
+func (c *Coinbase) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		c.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/coinbase.go
+++ b/pkg/exchange/coinbase.go
@@ -51,11 +51,11 @@ func (c *Coinbase) getURL(pp *model.PricePoint) string {
 
 func (c *Coinbase) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		c.callOne(pp)
+		c.fetchOne(pp)
 	}
 }
 
-func (c *Coinbase) callOne(pp *model.PricePoint) {
+func (c *Coinbase) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/coinbase.go
+++ b/pkg/exchange/coinbase.go
@@ -55,6 +55,7 @@ func (c *Coinbase) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (c *Coinbase) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {

--- a/pkg/exchange/coinbase_test.go
+++ b/pkg/exchange/coinbase_test.go
@@ -56,20 +56,16 @@ func (suite *CoinbaseSuite) TestLocalPair() {
 }
 
 func (suite *CoinbaseSuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("coinbase", "BTC", "ETH")
+	pp := newPricePoint("coinbase", "BTC", "ETH")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -77,65 +73,72 @@ func (suite *CoinbaseSuite) TestFailOnWrongInput() {
 		Error: ourErr,
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(""),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"price":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"price":"1","ask":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"price":"1","ask":"1","volume":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"price":"1","ask":"1","volume":"1","bid":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 }
 
 func (suite *CoinbaseSuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("coinbase", "BTC", "ETH")
+	pp := newPricePoint("coinbase", "BTC", "ETH")
 	resp := &query.HTTPResponse{
 		Body: []byte(`{"price":"1","ask":"2","volume":"3","bid":"4"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(1.0, cr[0].PricePoint.Price)
-	suite.Equal(2.0, cr[0].PricePoint.Ask)
-	suite.Equal(3.0, cr[0].PricePoint.Volume)
-	suite.Equal(4.0, cr[0].PricePoint.Bid)
-	suite.Greater(cr[0].PricePoint.Timestamp, int64(2))
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(1.0, pps[0].Price)
+	suite.Equal(2.0, pps[0].Ask)
+	suite.Equal(3.0, pps[0].Volume)
+	suite.Equal(4.0, pps[0].Bid)
+	suite.Greater(pps[0].Timestamp, int64(2))
 }
 
 func (suite *CoinbaseSuite) TestRealAPICall() {

--- a/pkg/exchange/coinbasepro.go
+++ b/pkg/exchange/coinbasepro.go
@@ -55,6 +55,7 @@ func (c *CoinbasePro) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (c *CoinbasePro) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {

--- a/pkg/exchange/coinbasepro.go
+++ b/pkg/exchange/coinbasepro.go
@@ -49,9 +49,9 @@ func (c *CoinbasePro) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(coinbaseProURL, c.localPairName(pp.Pair))
 }
 
-func (c *CoinbasePro) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		c.callOne(ppp)
+func (c *CoinbasePro) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		c.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/coinbasepro.go
+++ b/pkg/exchange/coinbasepro.go
@@ -45,25 +45,21 @@ func (c *CoinbasePro) localPairName(pair *model.Pair) string {
 	return fmt.Sprintf("%s-%s", strings.ToUpper(pair.Base), strings.ToUpper(pair.Quote))
 }
 
-func (c *CoinbasePro) getURL(pp *model.PotentialPricePoint) string {
+func (c *CoinbasePro) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(coinbaseProURL, c.localPairName(pp.Pair))
 }
 
-func (c *CoinbasePro) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
+func (c *CoinbasePro) Fetch(ppps []*model.PricePoint) {
 	for _, ppp := range ppps {
-		pp, err := c.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
+		c.callOne(ppp)
 	}
-
-	return cr
 }
 
-func (c *CoinbasePro) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {
-	err := model.ValidatePotentialPricePoint(pp)
+func (c *CoinbasePro) callOne(pp *model.PricePoint) {
+	err := model.ValidatePricePoint(pp)
 	if err != nil {
-		return nil, err
+		pp.Error = err
+		return
 	}
 
 	req := &query.HTTPRequest{
@@ -73,45 +69,48 @@ func (c *CoinbasePro) callOne(pp *model.PotentialPricePoint) (*model.PricePoint,
 	// make query
 	res := c.Pool.Query(req)
 	if res == nil {
-		return nil, errEmptyExchangeResponse
+		pp.Error = errEmptyExchangeResponse
+		return
 	}
 	if res.Error != nil {
-		return nil, res.Error
+		pp.Error = res.Error
+		return
 	}
 	// parsing JSON
 	var resp coinbaseProResponse
 	err = json.Unmarshal(res.Body, &resp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse coinbasepro response: %w", err)
+		pp.Error = fmt.Errorf("failed to parse coinbasepro response: %w", err)
+		return
 	}
 	// Parsing price from string
 	price, err := strconv.ParseFloat(resp.Price, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse price from coinbasepro exchange %s", res.Body)
+		pp.Error = fmt.Errorf("failed to parse price from coinbasepro exchange %s", res.Body)
+		return
 	}
 	// Parsing ask from string
 	ask, err := strconv.ParseFloat(resp.Ask, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse ask from coinbasepro exchange %s", res.Body)
+		pp.Error = fmt.Errorf("failed to parse ask from coinbasepro exchange %s", res.Body)
+		return
 	}
 	// Parsing volume from string
 	volume, err := strconv.ParseFloat(resp.Volume, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse volume from coinbasepro exchange %s", res.Body)
+		pp.Error = fmt.Errorf("failed to parse volume from coinbasepro exchange %s", res.Body)
+		return
 	}
 	// Parsing bid from string
 	bid, err := strconv.ParseFloat(resp.Bid, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse bid from coinbasepro exchange %s", res.Body)
+		pp.Error = fmt.Errorf("failed to parse bid from coinbasepro exchange %s", res.Body)
+		return
 	}
-	// building PricePoint
-	return &model.PricePoint{
-		Exchange:  pp.Exchange,
-		Pair:      pp.Pair,
-		Price:     price,
-		Volume:    volume,
-		Ask:       ask,
-		Bid:       bid,
-		Timestamp: time.Now().Unix(),
-	}, nil
+
+	pp.Price = price
+	pp.Volume = volume
+	pp.Ask = ask
+	pp.Bid = bid
+	pp.Timestamp = time.Now().Unix()
 }

--- a/pkg/exchange/coinbasepro.go
+++ b/pkg/exchange/coinbasepro.go
@@ -51,11 +51,11 @@ func (c *CoinbasePro) getURL(pp *model.PricePoint) string {
 
 func (c *CoinbasePro) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		c.callOne(pp)
+		c.fetchOne(pp)
 	}
 }
 
-func (c *CoinbasePro) callOne(pp *model.PricePoint) {
+func (c *CoinbasePro) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/coinbasepro_test.go
+++ b/pkg/exchange/coinbasepro_test.go
@@ -56,20 +56,16 @@ func (suite *CoinbaseProSuite) TestLocalPair() {
 }
 
 func (suite *CoinbaseProSuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("coinbasepro", "BTC", "ETH")
+	pp := newPricePoint("coinbasepro", "BTC", "ETH")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -77,65 +73,72 @@ func (suite *CoinbaseProSuite) TestFailOnWrongInput() {
 		Error: ourErr,
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(""),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"price":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"price":"1","ask":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"price":"1","ask":"1","volume":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"price":"1","ask":"1","volume":"1","bid":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 }
 
 func (suite *CoinbaseProSuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("coinbasepro", "BTC", "ETH")
+	pp := newPricePoint("coinbasepro", "BTC", "ETH")
 	resp := &query.HTTPResponse{
 		Body: []byte(`{"price":"1","ask":"2","volume":"3","bid":"4"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(1.0, cr[0].PricePoint.Price)
-	suite.Equal(2.0, cr[0].PricePoint.Ask)
-	suite.Equal(3.0, cr[0].PricePoint.Volume)
-	suite.Equal(4.0, cr[0].PricePoint.Bid)
-	suite.Greater(cr[0].PricePoint.Timestamp, int64(2))
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(1.0, pps[0].Price)
+	suite.Equal(2.0, pps[0].Ask)
+	suite.Equal(3.0, pps[0].Volume)
+	suite.Equal(4.0, pps[0].Bid)
+	suite.Greater(pps[0].Timestamp, int64(2))
 }
 
 func (suite *CoinbaseProSuite) TestRealAPICall() {

--- a/pkg/exchange/cryptocompare.go
+++ b/pkg/exchange/cryptocompare.go
@@ -38,9 +38,9 @@ func (c *CryptoCompare) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(cryptoCompareURL, pp.Pair.Base, pp.Pair.Quote)
 }
 
-func (c *CryptoCompare) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		c.callOne(ppp)
+func (c *CryptoCompare) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		c.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/cryptocompare.go
+++ b/pkg/exchange/cryptocompare.go
@@ -44,6 +44,7 @@ func (c *CryptoCompare) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (c *CryptoCompare) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {

--- a/pkg/exchange/cryptocompare.go
+++ b/pkg/exchange/cryptocompare.go
@@ -40,11 +40,11 @@ func (c *CryptoCompare) getURL(pp *model.PricePoint) string {
 
 func (c *CryptoCompare) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		c.callOne(pp)
+		c.fetchOne(pp)
 	}
 }
 
-func (c *CryptoCompare) callOne(pp *model.PricePoint) {
+func (c *CryptoCompare) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/cryptocompare_test.go
+++ b/pkg/exchange/cryptocompare_test.go
@@ -51,20 +51,16 @@ func (suite *CryptoCompareSuite) TearDownTest() {
 }
 
 func (suite *CryptoCompareSuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("cryptocompare", "BTC", "ETH")
+	pp := newPricePoint("cryptocompare", "BTC", "ETH")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -72,8 +68,9 @@ func (suite *CryptoCompareSuite) TestFailOnWrongInput() {
 		Error: ourErr,
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	for n, r := range [][]byte{
 		// invalid response
@@ -88,24 +85,26 @@ func (suite *CryptoCompareSuite) TestFailOnWrongInput() {
 		suite.T().Run(fmt.Sprintf("Case-%d", n+1), func(t *testing.T) {
 			resp = &query.HTTPResponse{Body: r}
 			suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-			cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-			suite.Error(cr[0].Error)
+			pps = []*model.PricePoint{pp}
+			suite.exchange.Fetch(pps)
+			suite.Error(pps[0].Error)
 		})
 	}
 }
 
 func (suite *CryptoCompareSuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("cryptocompare", "BTC", "ETH")
+	pp := newPricePoint("cryptocompare", "BTC", "ETH")
 	resp := &query.HTTPResponse{
 		Body: []byte(`{"ETH":1.1}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(1.1, cr[0].PricePoint.Price)
-	suite.Greater(cr[0].PricePoint.Timestamp, int64(0))
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(1.1, pps[0].Price)
+	suite.Greater(pps[0].Timestamp, int64(0))
 }
 
 func (suite *CryptoCompareSuite) TestRealAPICall() {

--- a/pkg/exchange/ddex.go
+++ b/pkg/exchange/ddex.go
@@ -63,6 +63,7 @@ func (d *Ddex) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (d *Ddex) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {

--- a/pkg/exchange/ddex.go
+++ b/pkg/exchange/ddex.go
@@ -59,11 +59,11 @@ func (d *Ddex) getURL(pp *model.PricePoint) string {
 
 func (d *Ddex) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		d.callOne(pp)
+		d.fetchOne(pp)
 	}
 }
 
-func (d *Ddex) callOne(pp *model.PricePoint) {
+func (d *Ddex) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/ddex.go
+++ b/pkg/exchange/ddex.go
@@ -57,9 +57,9 @@ func (d *Ddex) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(ddexURL, d.localPairName(pp.Pair))
 }
 
-func (d *Ddex) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		d.callOne(ppp)
+func (d *Ddex) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		d.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/ddex_test.go
+++ b/pkg/exchange/ddex_test.go
@@ -56,20 +56,16 @@ func (suite *DdexSuite) TestLocalPair() {
 }
 
 func (suite *DdexSuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("ddex", "BTC", "ETH")
+	pp := newPricePoint("ddex", "BTC", "ETH")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -77,16 +73,18 @@ func (suite *DdexSuite) TestFailOnWrongInput() {
 		Error: ourErr,
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(""),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	for n, r := range [][]byte{
 		// invalid desc
@@ -183,14 +181,15 @@ func (suite *DdexSuite) TestFailOnWrongInput() {
 		suite.T().Run(fmt.Sprintf("Case-%d", n+1), func(t *testing.T) {
 			resp = &query.HTTPResponse{Body: r}
 			suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-			cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-			suite.Error(cr[0].Error)
+			pps = []*model.PricePoint{pp}
+			suite.exchange.Fetch(pps)
+			suite.Error(pps[0].Error)
 		})
 	}
 }
 
 func (suite *DdexSuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("ddex", "BTC", "ETH")
+	pp := newPricePoint("ddex", "BTC", "ETH")
 	resp := &query.HTTPResponse{
 		Body: []byte(`{
 		   "status":0,
@@ -218,13 +217,14 @@ func (suite *DdexSuite) TestSuccessResponse() {
 		}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(101.6, cr[0].PricePoint.Ask)
-	suite.Equal(100.5, cr[0].PricePoint.Bid)
-	suite.Equal(100.5, cr[0].PricePoint.Price)
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(101.6, pps[0].Ask)
+	suite.Equal(100.5, pps[0].Bid)
+	suite.Equal(100.5, pps[0].Price)
 }
 
 func (suite *DdexSuite) TestRealAPICall() {

--- a/pkg/exchange/errors.go
+++ b/pkg/exchange/errors.go
@@ -20,13 +20,13 @@ import (
 	"fmt"
 )
 
-var errNoPotentialPricePoint = fmt.Errorf("failed to make request to nil PotentialPricePoint")
+var errNoPricePoint = fmt.Errorf("failed to make request to nil PricePoint")
 
 //nolint:deadcode,varcheck,unused
-var errWrongPotentialPricePoint = fmt.Errorf("failed to make request using wrong PotentialPricePoint")
+var errWrongPricePoint = fmt.Errorf("failed to make request using wrong PricePoint")
 
 //nolint:deadcode,varcheck,unused
-var errNoExchangeInPotentialPricePoint = fmt.Errorf("failed to make request for nil exchange in given PotentialPricePoint")
+var errNoExchangeInPricePoint = fmt.Errorf("failed to make request for nil exchange in given PricePoint")
 
 var errEmptyExchangeResponse = fmt.Errorf("empty exchange response received")
 

--- a/pkg/exchange/errors.go
+++ b/pkg/exchange/errors.go
@@ -20,14 +20,5 @@ import (
 	"fmt"
 )
 
-var errNoPricePoint = fmt.Errorf("failed to make request to nil PricePoint")
-
-//nolint:deadcode,varcheck,unused
-var errWrongPricePoint = fmt.Errorf("failed to make request using wrong PricePoint")
-
-//nolint:deadcode,varcheck,unused
-var errNoExchangeInPricePoint = fmt.Errorf("failed to make request for nil exchange in given PricePoint")
-
 var errEmptyExchangeResponse = fmt.Errorf("empty exchange response received")
-
 var errUnknownExchange = errors.New("unknown exchange")

--- a/pkg/exchange/exchanges_test.go
+++ b/pkg/exchange/exchanges_test.go
@@ -46,20 +46,22 @@ func (suite *ExchangesSuite) SetupSuite() {
 }
 
 func (suite *ExchangesSuite) TestCallErrorNegative() {
-	cr := suite.set.Call([]*model.PotentialPricePoint{{}})
-	assert.Error(suite.T(), cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.set.Fetch(pps)
+	assert.Error(suite.T(), pps[0].Error)
 
 	ex := &model.Exchange{Name: "unknown"}
-	pp := &model.PotentialPricePoint{
+	pp := &model.PricePoint{
 		Exchange: ex,
 	}
-	cr = suite.set.Call([]*model.PotentialPricePoint{pp})
-	assert.Same(suite.T(), ex, cr[0].PricePoint.Exchange)
-	assert.Error(suite.T(), cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.set.Fetch(pps)
+	assert.Same(suite.T(), ex, pps[0].Exchange)
+	assert.Error(suite.T(), pps[0].Error)
 }
 
 func (suite *ExchangesSuite) TestFailWithNilResponseForBinance() {
-	pp := &model.PotentialPricePoint{
+	pp := &model.PricePoint{
 		Exchange: &model.Exchange{
 			Name: "binance",
 		},
@@ -69,10 +71,11 @@ func (suite *ExchangesSuite) TestFailWithNilResponseForBinance() {
 		},
 	}
 
-	cr := suite.set.Call([]*model.PotentialPricePoint{pp})
+	pps := []*model.PricePoint{pp}
+	suite.set.Fetch(pps)
 
-	assert.Error(suite.T(), cr[0].Error)
-	assert.Nil(suite.T(), cr[0].PricePoint)
+	assert.Error(suite.T(), pps[0].Error)
+	assert.NotNil(suite.T(), pps[0])
 }
 
 func (suite *ExchangesSuite) TestSuccessBinance() {
@@ -87,18 +90,19 @@ func (suite *ExchangesSuite) TestSuccessBinance() {
 		Quote: "ETH",
 	}
 	suite.pool.MockResp(resp)
-	pp := &model.PotentialPricePoint{
+	pp := &model.PricePoint{
 		Exchange: &model.Exchange{
 			Name: "binance",
 		},
 		Pair: p,
 	}
 
-	cr := suite.set.Call([]*model.PotentialPricePoint{pp})
+	pps := []*model.PricePoint{pp}
+	suite.set.Fetch(pps)
 
-	assert.NoError(suite.T(), cr[0].Error)
-	assert.EqualValues(suite.T(), p, cr[0].PricePoint.Pair)
-	assert.EqualValues(suite.T(), price, cr[0].PricePoint.Price)
+	assert.NoError(suite.T(), pps[0].Error)
+	assert.EqualValues(suite.T(), p, pps[0].Pair)
+	assert.EqualValues(suite.T(), price, pps[0].Price)
 }
 
 // In order for 'go test' to run this suite, we need to create

--- a/pkg/exchange/folgory.go
+++ b/pkg/exchange/folgory.go
@@ -48,9 +48,9 @@ func (f *Folgory) localPairName(pair *model.Pair) string {
 	return fmt.Sprintf("%s/%s", f.renameSymbol(pair.Base), f.renameSymbol(pair.Quote))
 }
 
-func (f *Folgory) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		f.callOne(ppp)
+func (f *Folgory) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		f.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/folgory.go
+++ b/pkg/exchange/folgory.go
@@ -50,11 +50,11 @@ func (f *Folgory) localPairName(pair *model.Pair) string {
 
 func (f *Folgory) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		f.callOne(pp)
+		f.fetchOne(pp)
 	}
 }
 
-func (f *Folgory) callOne(pp *model.PricePoint) {
+func (f *Folgory) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/folgory.go
+++ b/pkg/exchange/folgory.go
@@ -54,6 +54,7 @@ func (f *Folgory) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (f *Folgory) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {

--- a/pkg/exchange/folgory_test.go
+++ b/pkg/exchange/folgory_test.go
@@ -56,20 +56,16 @@ func (suite *FolgorySuite) TestLocalPair() {
 }
 
 func (suite *FolgorySuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("folgory", "BTC", "ETH")
+	pp := newPricePoint("folgory", "BTC", "ETH")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -77,55 +73,61 @@ func (suite *FolgorySuite) TestFailOnWrongInput() {
 		Error: ourErr,
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(""),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`[]`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`[{"symbol":"BTC/ETH","last":"abc"}]`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`[{"symbol":"BTC/ETH","last":"1","volume":"abc"}]`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 }
 
 func (suite *FolgorySuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("folgory", "BTC", "ETH")
+	pp := newPricePoint("folgory", "BTC", "ETH")
 	resp := &query.HTTPResponse{
 		Body: []byte(`[{"symbol":"BTC/ETH","last":"1","volume":"2"}]`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(1.0, cr[0].PricePoint.Price)
-	suite.Equal(2.0, cr[0].PricePoint.Volume)
-	suite.Greater(cr[0].PricePoint.Timestamp, int64(2))
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(1.0, pps[0].Price)
+	suite.Equal(2.0, pps[0].Volume)
+	suite.Greater(pps[0].Timestamp, int64(2))
 }
 
 func (suite *FolgorySuite) TestRealAPICall() {

--- a/pkg/exchange/ftx.go
+++ b/pkg/exchange/ftx.go
@@ -51,9 +51,9 @@ func (f *Ftx) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(ftxURL, f.localPairName(pp.Pair))
 }
 
-func (f *Ftx) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		f.callOne(ppp)
+func (f *Ftx) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		f.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/ftx.go
+++ b/pkg/exchange/ftx.go
@@ -53,11 +53,11 @@ func (f *Ftx) getURL(pp *model.PricePoint) string {
 
 func (f *Ftx) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		f.callOne(pp)
+		f.fetchOne(pp)
 	}
 }
 
-func (f *Ftx) callOne(pp *model.PricePoint) {
+func (f *Ftx) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/ftx.go
+++ b/pkg/exchange/ftx.go
@@ -57,6 +57,7 @@ func (f *Ftx) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (f *Ftx) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {

--- a/pkg/exchange/fx.go
+++ b/pkg/exchange/fx.go
@@ -51,11 +51,11 @@ func (f *Fx) getURL(pp *model.PricePoint) string {
 
 func (f *Fx) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		f.callOne(pp)
+		f.fetchOne(pp)
 	}
 }
 
-func (f *Fx) callOne(pp *model.PricePoint) {
+func (f *Fx) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/fx.go
+++ b/pkg/exchange/fx.go
@@ -49,9 +49,9 @@ func (f *Fx) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(fxURL, f.localPairName(pp.Pair))
 }
 
-func (f *Fx) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		f.callOne(ppp)
+func (f *Fx) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		f.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/fx.go
+++ b/pkg/exchange/fx.go
@@ -55,6 +55,7 @@ func (f *Fx) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (f *Fx) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {

--- a/pkg/exchange/fx_test.go
+++ b/pkg/exchange/fx_test.go
@@ -55,20 +55,16 @@ func (suite *FxSuite) TestLocalPair() {
 }
 
 func (suite *FxSuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("fx", "BTC", "ETH")
+	pp := newPricePoint("fx", "BTC", "ETH")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -76,46 +72,51 @@ func (suite *FxSuite) TestFailOnWrongInput() {
 		Error: ourErr,
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(""),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error convert price to number
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"rates":{}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error convert price to number
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"rates":{"ETH":"abcd"}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 }
 
 func (suite *FxSuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("fx", "BTC", "ETH")
+	pp := newPricePoint("fx", "BTC", "ETH")
 	resp := &query.HTTPResponse{
 		Body: []byte(`{"rates":{"ETH":1}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(1.0, cr[0].PricePoint.Price)
-	suite.Greater(cr[0].PricePoint.Timestamp, int64(0))
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(1.0, pps[0].Price)
+	suite.Greater(pps[0].Timestamp, int64(0))
 }
 
 func (suite *FxSuite) TestRealAPICall() {

--- a/pkg/exchange/gateio.go
+++ b/pkg/exchange/gateio.go
@@ -58,9 +58,9 @@ func (g *Gateio) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(gateioURL, g.localPairName(pp.Pair))
 }
 
-func (g *Gateio) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		g.callOne(ppp)
+func (g *Gateio) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		g.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/gateio.go
+++ b/pkg/exchange/gateio.go
@@ -64,6 +64,7 @@ func (g *Gateio) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (g *Gateio) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {

--- a/pkg/exchange/gateio.go
+++ b/pkg/exchange/gateio.go
@@ -60,11 +60,11 @@ func (g *Gateio) getURL(pp *model.PricePoint) string {
 
 func (g *Gateio) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		g.callOne(pp)
+		g.fetchOne(pp)
 	}
 }
 
-func (g *Gateio) callOne(pp *model.PricePoint) {
+func (g *Gateio) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/gateio_test.go
+++ b/pkg/exchange/gateio_test.go
@@ -56,20 +56,16 @@ func (suite *GateioSuite) TestLocalPair() {
 }
 
 func (suite *GateioSuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("gateio", "BTC", "ETH")
+	pp := newPricePoint("gateio", "BTC", "ETH")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -77,57 +73,63 @@ func (suite *GateioSuite) TestFailOnWrongInput() {
 		Error: ourErr,
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(""),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte("[{}]"),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`[{"last":"abc"}]`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`[{"last":"1","currency_pair":"abc"}]`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 }
 
 func (suite *GateioSuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("gateio", "BTC", "ETH")
+	pp := newPricePoint("gateio", "BTC", "ETH")
 	resp := &query.HTTPResponse{
 		Body: []byte(`[{"currency_pair":"BTC_ETH","last":"1","lowest_ask":"2","highest_bid":"3","quote_volume":"4"}]`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(1.0, cr[0].PricePoint.Price)
-	suite.Equal(2.0, cr[0].PricePoint.Ask)
-	suite.Equal(3.0, cr[0].PricePoint.Bid)
-	suite.Equal(4.0, cr[0].PricePoint.Volume)
-	suite.Greater(cr[0].PricePoint.Timestamp, int64(2))
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(1.0, pps[0].Price)
+	suite.Equal(2.0, pps[0].Ask)
+	suite.Equal(3.0, pps[0].Bid)
+	suite.Equal(4.0, pps[0].Volume)
+	suite.Greater(pps[0].Timestamp, int64(2))
 }
 
 func (suite *GateioSuite) TestRealAPICall() {

--- a/pkg/exchange/gemini.go
+++ b/pkg/exchange/gemini.go
@@ -52,11 +52,11 @@ func (g *Gemini) getURL(pp *model.PricePoint) string {
 
 func (g *Gemini) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		g.callOne(pp)
+		g.fetchOne(pp)
 	}
 }
 
-func (g *Gemini) callOne(pp *model.PricePoint) {
+func (g *Gemini) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/gemini.go
+++ b/pkg/exchange/gemini.go
@@ -50,9 +50,9 @@ func (g *Gemini) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(geminiURL, g.localPairName(pp.Pair))
 }
 
-func (g *Gemini) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		g.callOne(ppp)
+func (g *Gemini) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		g.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/gemini.go
+++ b/pkg/exchange/gemini.go
@@ -56,6 +56,7 @@ func (g *Gemini) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (g *Gemini) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
@@ -103,8 +104,10 @@ func (g *Gemini) fetchOne(pp *model.PricePoint) {
 		return
 	}
 
+	const nanoseconds = 1000
+
 	pp.Price = price
 	pp.Ask = ask
 	pp.Bid = bid
-	pp.Timestamp = resp.Volume.Timestamp / 1000
+	pp.Timestamp = resp.Volume.Timestamp / nanoseconds
 }

--- a/pkg/exchange/gemini_test.go
+++ b/pkg/exchange/gemini_test.go
@@ -56,20 +56,16 @@ func (suite *GeminiSuite) TestLocalPair() {
 }
 
 func (suite *GeminiSuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("gemini", "BTC", "ETH")
+	pp := newPricePoint("gemini", "BTC", "ETH")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -77,56 +73,62 @@ func (suite *GeminiSuite) TestFailOnWrongInput() {
 		Error: ourErr,
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(""),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"last":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"last":"1","ask":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"last":"1","ask":"1","bid":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 }
 
 func (suite *GeminiSuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("gemini", "BTC", "ETH")
+	pp := newPricePoint("gemini", "BTC", "ETH")
 	resp := &query.HTTPResponse{
 		Body: []byte(`{"last":"1","ask":"2","bid":"4","volume":{"timestamp":2000}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(1.0, cr[0].PricePoint.Price)
-	suite.Equal(2.0, cr[0].PricePoint.Ask)
-	suite.Equal(4.0, cr[0].PricePoint.Bid)
-	suite.Equal(cr[0].PricePoint.Timestamp, int64(2))
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(1.0, pps[0].Price)
+	suite.Equal(2.0, pps[0].Ask)
+	suite.Equal(4.0, pps[0].Bid)
+	suite.Equal(pps[0].Timestamp, int64(2))
 }
 
 func (suite *GeminiSuite) TestRealAPICall() {

--- a/pkg/exchange/hitbtc.go
+++ b/pkg/exchange/hitbtc.go
@@ -56,6 +56,7 @@ func (h *Hitbtc) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (h *Hitbtc) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {

--- a/pkg/exchange/hitbtc.go
+++ b/pkg/exchange/hitbtc.go
@@ -52,11 +52,11 @@ func (h *Hitbtc) getURL(pp *model.PricePoint) string {
 
 func (h *Hitbtc) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		h.callOne(pp)
+		h.fetchOne(pp)
 	}
 }
 
-func (h *Hitbtc) callOne(pp *model.PricePoint) {
+func (h *Hitbtc) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/hitbtc.go
+++ b/pkg/exchange/hitbtc.go
@@ -50,9 +50,9 @@ func (h *Hitbtc) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(hitbtcURL, h.localPairName(pp.Pair))
 }
 
-func (h *Hitbtc) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		h.callOne(ppp)
+func (h *Hitbtc) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		h.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/hitbtc_test.go
+++ b/pkg/exchange/hitbtc_test.go
@@ -56,20 +56,16 @@ func (suite *HitbtcSuite) TestLocalPair() {
 }
 
 func (suite *HitbtcSuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("hitbtc", "BTC", "ETH")
+	pp := newPricePoint("hitbtc", "BTC", "ETH")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -77,65 +73,72 @@ func (suite *HitbtcSuite) TestFailOnWrongInput() {
 		Error: ourErr,
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(""),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"last":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"last":"1","ask":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"last":"1","ask":"1","volume":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"last":"1","ask":"1","volume":"1","bid":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 }
 
 func (suite *HitbtcSuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("hitbtc", "BTC", "ETH")
+	pp := newPricePoint("hitbtc", "BTC", "ETH")
 	resp := &query.HTTPResponse{
 		Body: []byte(`{"last":"1","ask":"2","volume":"3","bid":"4","timestamp":"2020-04-24T20:09:36.229Z"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(1.0, cr[0].PricePoint.Price)
-	suite.Equal(2.0, cr[0].PricePoint.Ask)
-	suite.Equal(3.0, cr[0].PricePoint.Volume)
-	suite.Equal(4.0, cr[0].PricePoint.Bid)
-	suite.Greater(cr[0].PricePoint.Timestamp, int64(2))
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(1.0, pps[0].Price)
+	suite.Equal(2.0, pps[0].Ask)
+	suite.Equal(3.0, pps[0].Volume)
+	suite.Equal(4.0, pps[0].Bid)
+	suite.Greater(pps[0].Timestamp, int64(2))
 }
 
 func (suite *HitbtcSuite) TestRealAPICall() {

--- a/pkg/exchange/huobi.go
+++ b/pkg/exchange/huobi.go
@@ -51,11 +51,11 @@ func (h *Huobi) getURL(pp *model.PricePoint) string {
 
 func (h *Huobi) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		h.callOne(pp)
+		h.fetchOne(pp)
 	}
 }
 
-func (h *Huobi) callOne(pp *model.PricePoint) {
+func (h *Huobi) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/huobi.go
+++ b/pkg/exchange/huobi.go
@@ -55,6 +55,7 @@ func (h *Huobi) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (h *Huobi) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
@@ -91,7 +92,9 @@ func (h *Huobi) fetchOne(pp *model.PricePoint) {
 		return
 	}
 
+	const nanoseconds = 1000
+
 	pp.Price = resp.Tick.Bid[0]
 	pp.Volume = resp.Volume
-	pp.Timestamp = resp.Timestamp / 1000
+	pp.Timestamp = resp.Timestamp / nanoseconds
 }

--- a/pkg/exchange/huobi.go
+++ b/pkg/exchange/huobi.go
@@ -49,9 +49,9 @@ func (h *Huobi) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(huobiURL, h.localPairName(pp.Pair))
 }
 
-func (h *Huobi) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		h.callOne(ppp)
+func (h *Huobi) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		h.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/huobi_test.go
+++ b/pkg/exchange/huobi_test.go
@@ -56,20 +56,16 @@ func (suite *HuobiSuite) TestLocalPair() {
 }
 
 func (suite *HuobiSuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("huobi", "BTC", "ETH")
+	pp := newPricePoint("huobi", "BTC", "ETH")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -77,64 +73,71 @@ func (suite *HuobiSuite) TestFailOnWrongInput() {
 		Error: ourErr,
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(""),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"status":"error"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"status":"success","vol":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"status":"success","vol":"1","ts":"abc"}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"status":"success","vol":"1","ts":2,"tick":{"bid":["abc"]}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 }
 
 func (suite *HuobiSuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("huobi", "BTC", "ETH")
+	pp := newPricePoint("huobi", "BTC", "ETH")
 	resp := &query.HTTPResponse{
 		Body: []byte(`{"status":"success","vol":1.3,"ts":2000,"tick":{"bid":[2.1,3.4]}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
 
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(1.3, cr[0].PricePoint.Volume)
-	suite.Equal(2.1, cr[0].PricePoint.Price)
-	suite.Equal(cr[0].PricePoint.Timestamp, int64(2))
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(1.3, pps[0].Volume)
+	suite.Equal(2.1, pps[0].Price)
+	suite.Equal(pps[0].Timestamp, int64(2))
 }
 
 func (suite *HuobiSuite) TestRealAPICall() {

--- a/pkg/exchange/kraken.go
+++ b/pkg/exchange/kraken.go
@@ -103,9 +103,9 @@ func (k *Kraken) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(krakenURL, k.getPair(pp))
 }
 
-func (k *Kraken) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		k.callOne(ppp)
+func (k *Kraken) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		k.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/kraken.go
+++ b/pkg/exchange/kraken.go
@@ -105,11 +105,11 @@ func (k *Kraken) getURL(pp *model.PricePoint) string {
 
 func (k *Kraken) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		k.callOne(pp)
+		k.fetchOne(pp)
 	}
 }
 
-func (k *Kraken) callOne(pp *model.PricePoint) {
+func (k *Kraken) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/kraken.go
+++ b/pkg/exchange/kraken.go
@@ -109,6 +109,7 @@ func (k *Kraken) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (k *Kraken) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {

--- a/pkg/exchange/kraken_test.go
+++ b/pkg/exchange/kraken_test.go
@@ -56,20 +56,16 @@ func (suite *KrakenSuite) TestLocalPair() {
 }
 
 func (suite *KrakenSuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("kraken", "DAI", "USD")
+	pp := newPricePoint("kraken", "DAI", "USD")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -77,55 +73,61 @@ func (suite *KrakenSuite) TestFailOnWrongInput() {
 		Error: ourErr,
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(""),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"error":["abcd"]}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"error":[], "result":{}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"error":[], "result":{"XDAIZUSD":{}}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 }
 
 func (suite *KrakenSuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("kraken", "DAI", "USD")
+	pp := newPricePoint("kraken", "DAI", "USD")
 	resp := &query.HTTPResponse{
 		Body: []byte(`{"error":[],"result":{"DAIZUSD":{"c":["1"],"v":["2"]}}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(1.0, cr[0].PricePoint.Price)
-	suite.Equal(2.0, cr[0].PricePoint.Volume)
-	suite.Greater(cr[0].PricePoint.Timestamp, int64(0))
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(1.0, pps[0].Price)
+	suite.Equal(2.0, pps[0].Volume)
+	suite.Greater(pps[0].Timestamp, int64(0))
 }
 
 func (suite *KrakenSuite) TestRealAPICall() {

--- a/pkg/exchange/kucoin.go
+++ b/pkg/exchange/kucoin.go
@@ -56,6 +56,7 @@ func (k *Kucoin) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (k *Kucoin) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
@@ -102,11 +103,11 @@ func (k *Kucoin) fetchOne(pp *model.PricePoint) {
 		pp.Error = fmt.Errorf("failed to parse bid from kucoin exchange %s", res.Body)
 		return
 	}
-	// Parsing volume from string
 
-	pp.Timestamp = resp.Data.Time / 1000
+	const nanoseconds = 1000
 
 	pp.Price = price
 	pp.Ask = bid
 	pp.Bid = ask
+	pp.Timestamp = resp.Data.Time / nanoseconds
 }

--- a/pkg/exchange/kucoin.go
+++ b/pkg/exchange/kucoin.go
@@ -46,25 +46,21 @@ func (k *Kucoin) localPairName(pair *model.Pair) string {
 	return fmt.Sprintf("%s-%s", pair.Base, pair.Quote)
 }
 
-func (k *Kucoin) getURL(pp *model.PotentialPricePoint) string {
+func (k *Kucoin) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(kucoinURL, k.localPairName(pp.Pair))
 }
 
-func (k *Kucoin) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
+func (k *Kucoin) Fetch(ppps []*model.PricePoint) {
 	for _, ppp := range ppps {
-		pp, err := k.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
+		k.callOne(ppp)
 	}
-
-	return cr
 }
 
-func (k *Kucoin) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {
-	err := model.ValidatePotentialPricePoint(pp)
+func (k *Kucoin) callOne(pp *model.PricePoint) {
+	err := model.ValidatePricePoint(pp)
 	if err != nil {
-		return nil, err
+		pp.Error = err
+		return
 	}
 
 	req := &query.HTTPRequest{
@@ -74,40 +70,43 @@ func (k *Kucoin) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, erro
 	// make query
 	res := k.Pool.Query(req)
 	if res == nil {
-		return nil, errEmptyExchangeResponse
+		pp.Error = errEmptyExchangeResponse
+		return
 	}
 	if res.Error != nil {
-		return nil, res.Error
+		pp.Error = res.Error
+		return
 	}
 	// parsing JSON
 	var resp kucoinResponse
 	err = json.Unmarshal(res.Body, &resp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse kucoin response: %w", err)
+		pp.Error = fmt.Errorf("failed to parse kucoin response: %w", err)
+		return
 	}
 	// Parsing price from string
 	price, err := strconv.ParseFloat(resp.Data.Price, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse price from kucoin exchange %s", res.Body)
+		pp.Error = fmt.Errorf("failed to parse price from kucoin exchange %s", res.Body)
+		return
 	}
 	// Parsing ask from string
 	ask, err := strconv.ParseFloat(resp.Data.BestAsk, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse ask from kucoin exchange %s", res.Body)
+		pp.Error = fmt.Errorf("failed to parse ask from kucoin exchange %s", res.Body)
+		return
 	}
 	// Parsing bid from string
 	bid, err := strconv.ParseFloat(resp.Data.BestBid, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse bid from kucoin exchange %s", res.Body)
+		pp.Error = fmt.Errorf("failed to parse bid from kucoin exchange %s", res.Body)
+		return
 	}
 	// Parsing volume from string
-	// building PricePoint
-	return &model.PricePoint{
-		Timestamp: resp.Data.Time / 1000,
-		Exchange:  pp.Exchange,
-		Pair:      pp.Pair,
-		Price:     price,
-		Ask:       bid,
-		Bid:       ask,
-	}, nil
+
+	pp.Timestamp = resp.Data.Time / 1000
+
+	pp.Price = price
+	pp.Ask = bid
+	pp.Bid = ask
 }

--- a/pkg/exchange/kucoin.go
+++ b/pkg/exchange/kucoin.go
@@ -52,11 +52,11 @@ func (k *Kucoin) getURL(pp *model.PricePoint) string {
 
 func (k *Kucoin) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		k.callOne(pp)
+		k.fetchOne(pp)
 	}
 }
 
-func (k *Kucoin) callOne(pp *model.PricePoint) {
+func (k *Kucoin) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/kucoin.go
+++ b/pkg/exchange/kucoin.go
@@ -50,9 +50,9 @@ func (k *Kucoin) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(kucoinURL, k.localPairName(pp.Pair))
 }
 
-func (k *Kucoin) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		k.callOne(ppp)
+func (k *Kucoin) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		k.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/kucoin_test.go
+++ b/pkg/exchange/kucoin_test.go
@@ -56,20 +56,16 @@ func (suite *KucoinSuite) TestLocalPair() {
 }
 
 func (suite *KucoinSuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("kucoin", "BTC", "ETH")
+	pp := newPricePoint("kucoin", "BTC", "ETH")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -77,16 +73,18 @@ func (suite *KucoinSuite) TestFailOnWrongInput() {
 		Error: ourErr,
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(""),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	for n, r := range [][]byte{
 		// invalid price
@@ -135,14 +133,15 @@ func (suite *KucoinSuite) TestFailOnWrongInput() {
 		suite.T().Run(fmt.Sprintf("Case-%d", n+1), func(t *testing.T) {
 			resp = &query.HTTPResponse{Body: r}
 			suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-			cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-			suite.Error(cr[0].Error)
+			pps = []*model.PricePoint{pp}
+			suite.exchange.Fetch(pps)
+			suite.Error(pps[0].Error)
 		})
 	}
 }
 
 func (suite *KucoinSuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("kucoin", "BTC", "ETH")
+	pp := newPricePoint("kucoin", "BTC", "ETH")
 	resp := &query.HTTPResponse{
 		Body: []byte(`{
 			"code":"200000",
@@ -159,14 +158,15 @@ func (suite *KucoinSuite) TestSuccessResponse() {
 		}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(int64(1596632420), cr[0].PricePoint.Timestamp)
-	suite.Equal(1.23, cr[0].PricePoint.Price)
-	suite.Equal(1.3, cr[0].PricePoint.Bid)
-	suite.Equal(1.2, cr[0].PricePoint.Ask)
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(int64(1596632420), pps[0].Timestamp)
+	suite.Equal(1.23, pps[0].Price)
+	suite.Equal(1.3, pps[0].Bid)
+	suite.Equal(1.2, pps[0].Ask)
 }
 
 func (suite *KucoinSuite) TestRealAPICall() {

--- a/pkg/exchange/kyber.go
+++ b/pkg/exchange/kyber.go
@@ -67,6 +67,7 @@ func (k *Kyber) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (k *Kyber) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
@@ -106,27 +107,45 @@ func (k *Kyber) fetchOne(pp *model.PricePoint) {
 	result := resp.Result[0]
 
 	if len(result.SrcQty) == 0 || len(result.DstQty) == 0 {
-		pp.Error = fmt.Errorf("wrong kyber exchange response. No resulting pair %s data %+v", pp.Pair.String(), result)
+		pp.Error = fmt.Errorf(
+			"wrong kyber exchange response. No resulting pair %s data %+v",
+			pp.Pair.String(),
+			result,
+		)
 		return
 	}
 
 	if result.SrcQty[0] <= 0 {
-		pp.Error = fmt.Errorf("failed to parse price from kyber exchange (needs to be gtreater than 0) %s", res.Body)
+		pp.Error = fmt.Errorf(
+			"failed to parse price from kyber exchange (needs to be gtreater than 0) %s",
+			res.Body,
+		)
 		return
 	}
 
 	if result.DstQty[0] != refQty {
-		pp.Error = fmt.Errorf("failed to parse volume from kyber exchange (it needs to be %f) %s", refQty, res.Body)
+		pp.Error = fmt.Errorf(
+			"failed to parse volume from kyber exchange (it needs to be %f) %s",
+			refQty,
+			res.Body,
+		)
 		return
 	}
 
 	if result.Src != "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" {
-		pp.Error = fmt.Errorf("failed to parse price from kyber exchange (src needs to be 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee) %s", res.Body)
+		pp.Error = fmt.Errorf(
+			"failed to parse price from kyber exchange (src needs to be 0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee) %s",
+			res.Body,
+		)
 		return
 	}
 
 	if result.Dst != k.localPairName(pp.Pair) {
-		pp.Error = fmt.Errorf("failed to parse volume from kyber exchange (it needs to be %f) %s", refQty, res.Body)
+		pp.Error = fmt.Errorf(
+			"failed to parse volume from kyber exchange (it needs to be %f) %s",
+			refQty,
+			res.Body,
+		)
 		return
 	}
 

--- a/pkg/exchange/kyber.go
+++ b/pkg/exchange/kyber.go
@@ -63,11 +63,11 @@ func (k *Kyber) getURL(pp *model.PricePoint) string {
 
 func (k *Kyber) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		k.callOne(pp)
+		k.fetchOne(pp)
 	}
 }
 
-func (k *Kyber) callOne(pp *model.PricePoint) {
+func (k *Kyber) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/kyber.go
+++ b/pkg/exchange/kyber.go
@@ -61,9 +61,9 @@ func (k *Kyber) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(kyberURL, k.localPairName(pp.Pair), refQty)
 }
 
-func (k *Kyber) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		k.callOne(ppp)
+func (k *Kyber) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		k.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/loopring.go
+++ b/pkg/exchange/loopring.go
@@ -57,9 +57,9 @@ func (l *Loopring) getURL(pp *model.PricePoint) string {
 	return loopringURL
 }
 
-func (l *Loopring) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		l.callOne(ppp)
+func (l *Loopring) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		l.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/loopring.go
+++ b/pkg/exchange/loopring.go
@@ -63,6 +63,7 @@ func (l *Loopring) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (l *Loopring) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {

--- a/pkg/exchange/loopring.go
+++ b/pkg/exchange/loopring.go
@@ -53,25 +53,21 @@ func (l *Loopring) localPairName(pair *model.Pair) string {
 	return fmt.Sprintf("%s-%s", strings.ToUpper(pair.Base), strings.ToUpper(pair.Quote))
 }
 
-func (l *Loopring) getURL(pp *model.PotentialPricePoint) string {
+func (l *Loopring) getURL(pp *model.PricePoint) string {
 	return loopringURL
 }
 
-func (l *Loopring) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
+func (l *Loopring) Fetch(ppps []*model.PricePoint) {
 	for _, ppp := range ppps {
-		pp, err := l.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
+		l.callOne(ppp)
 	}
-
-	return cr
 }
 
-func (l *Loopring) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {
-	err := model.ValidatePotentialPricePoint(pp)
+func (l *Loopring) callOne(pp *model.PricePoint) {
+	err := model.ValidatePricePoint(pp)
 	if err != nil {
-		return nil, err
+		pp.Error = err
+		return
 	}
 	req := &query.HTTPRequest{
 		URL: l.getURL(pp),
@@ -79,54 +75,60 @@ func (l *Loopring) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, er
 	// make query
 	res := l.Pool.Query(req)
 	if res == nil {
-		return nil, errEmptyExchangeResponse
+		pp.Error = errEmptyExchangeResponse
+		return
 	}
 	if res.Error != nil {
-		return nil, res.Error
+		pp.Error = res.Error
+		return
 	}
 	// parsing JSON
 	var resp loopringResponse
 	err = json.Unmarshal(res.Body, &resp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse loopring response: %w", err)
+		pp.Error = fmt.Errorf("failed to parse loopring response: %w", err)
+		return
 	}
 	if resp.ResultInfo.Code != 0 || resp.ResultInfo.Message != "SUCCESS" {
-		return nil, fmt.Errorf("wrong loopring response %s", res.Body)
+		pp.Error = fmt.Errorf("wrong loopring response %s", res.Body)
+		return
 	}
 	if resp.Data == nil {
-		return nil, fmt.Errorf("empty `data` field for loopring response: %s", res.Body)
+		pp.Error = fmt.Errorf("empty `data` field for loopring response: %s", res.Body)
+		return
 	}
 	pair := l.localPairName(pp.Pair)
 	pairRes, ok := resp.Data[pair]
 	if !ok {
-		return nil, fmt.Errorf("no %s pair exist in loopring response: %s", pair, res.Body)
+		pp.Error = fmt.Errorf("no %s pair exist in loopring response: %s", pair, res.Body)
+		return
 	}
 	// Parsing price from string
 	price, err := strconv.ParseFloat(pairRes.Price, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse price from loopring exchange %s", res.Body)
+		pp.Error = fmt.Errorf("failed to parse price from loopring exchange %s", res.Body)
+		return
 	}
 	// Parsing price from string
 	volume, err := strconv.ParseFloat(pairRes.Volume, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse volume from loopring exchange %s", res.Body)
+		pp.Error = fmt.Errorf("failed to parse volume from loopring exchange %s", res.Body)
+		return
 	}
 	ask, err := strconv.ParseFloat(pairRes.Ask, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse ask from loopring exchange %s", res.Body)
+		pp.Error = fmt.Errorf("failed to parse ask from loopring exchange %s", res.Body)
+		return
 	}
 	bid, err := strconv.ParseFloat(pairRes.Bid, 64)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse bid from loopring exchange %s", res.Body)
+		pp.Error = fmt.Errorf("failed to parse bid from loopring exchange %s", res.Body)
+		return
 	}
-	// building PricePoint
-	return &model.PricePoint{
-		Exchange:  pp.Exchange,
-		Pair:      pp.Pair,
-		Price:     price,
-		Volume:    volume,
-		Ask:       ask,
-		Bid:       bid,
-		Timestamp: time.Now().Unix(),
-	}, nil
+
+	pp.Price = price
+	pp.Volume = volume
+	pp.Ask = ask
+	pp.Bid = bid
+	pp.Timestamp = time.Now().Unix()
 }

--- a/pkg/exchange/loopring.go
+++ b/pkg/exchange/loopring.go
@@ -59,11 +59,11 @@ func (l *Loopring) getURL(pp *model.PricePoint) string {
 
 func (l *Loopring) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		l.callOne(pp)
+		l.fetchOne(pp)
 	}
 }
 
-func (l *Loopring) callOne(pp *model.PricePoint) {
+func (l *Loopring) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/loopring_test.go
+++ b/pkg/exchange/loopring_test.go
@@ -87,20 +87,16 @@ func (suite *LoopringSuite) TestLocalPair() {
 }
 
 func (suite *LoopringSuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("loopring", "LRC", "USDT")
+	pp := newPricePoint("loopring", "LRC", "USDT")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -108,72 +104,80 @@ func (suite *LoopringSuite) TestFailOnWrongInput() {
 		Error: ourErr,
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(""),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte("{}"),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error wrong code
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"resultInfo":{"code":1,"message":"SUCCESS"}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error wrong message
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"resultInfo":{"code":0,"message":"Wrong"}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error no data
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"resultInfo":{"code":0,"message":"SUCCESS"}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 	// Error no pair in data
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"resultInfo":{"code":0,"message":"SUCCESS"},"data":{}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 }
 
 func (suite *LoopringSuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("loopring", "LRC", "USDT")
+	pp := newPricePoint("loopring", "LRC", "USDT")
 	resp := &query.HTTPResponse{
 		Body: []byte(successResponse),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(0.1221, cr[0].PricePoint.Price)
-	suite.Equal(181251.50, cr[0].PricePoint.Volume)
-	suite.Equal(0.1221, cr[0].PricePoint.Ask)
-	suite.Equal(0.1215, cr[0].PricePoint.Bid)
-	suite.Greater(cr[0].PricePoint.Timestamp, int64(2))
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(0.1221, pps[0].Price)
+	suite.Equal(181251.50, pps[0].Volume)
+	suite.Equal(0.1221, pps[0].Ask)
+	suite.Equal(0.1215, pps[0].Bid)
+	suite.Greater(pps[0].Timestamp, int64(2))
 }
 
 func (suite *LoopringSuite) TestRealAPICall() {

--- a/pkg/exchange/okex.go
+++ b/pkg/exchange/okex.go
@@ -63,6 +63,7 @@ func (o *Okex) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (o *Okex) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {

--- a/pkg/exchange/okex.go
+++ b/pkg/exchange/okex.go
@@ -57,9 +57,9 @@ func (o *Okex) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(okexURL, o.getPair(pp))
 }
 
-func (o *Okex) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		o.callOne(ppp)
+func (o *Okex) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		o.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/okex.go
+++ b/pkg/exchange/okex.go
@@ -59,11 +59,11 @@ func (o *Okex) getURL(pp *model.PricePoint) string {
 
 func (o *Okex) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		o.callOne(pp)
+		o.fetchOne(pp)
 	}
 }
 
-func (o *Okex) callOne(pp *model.PricePoint) {
+func (o *Okex) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/okex_test.go
+++ b/pkg/exchange/okex_test.go
@@ -56,20 +56,16 @@ func (suite *OkexSuite) TestLocalPair() {
 }
 
 func (suite *OkexSuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("okex", "BTC", "ETH")
+	pp := newPricePoint("okex", "BTC", "ETH")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -77,16 +73,18 @@ func (suite *OkexSuite) TestFailOnWrongInput() {
 		Error: ourErr,
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(""),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	for n, r := range [][]byte{
 		// invalid price
@@ -169,14 +167,15 @@ func (suite *OkexSuite) TestFailOnWrongInput() {
 		suite.T().Run(fmt.Sprintf("Case-%d", n+1), func(t *testing.T) {
 			resp = &query.HTTPResponse{Body: r}
 			suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-			cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-			suite.Error(cr[0].Error)
+			pps = []*model.PricePoint{pp}
+			suite.exchange.Fetch(pps)
+			suite.Error(pps[0].Error)
 		})
 	}
 }
 
 func (suite *OkexSuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("okex", "BTC", "ETH")
+	pp := newPricePoint("okex", "BTC", "ETH")
 	resp := &query.HTTPResponse{
 		Body: []byte(`{
 			"best_ask":"10000.5",
@@ -198,15 +197,16 @@ func (suite *OkexSuite) TestSuccessResponse() {
 		}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(int64(1596708166), cr[0].PricePoint.Timestamp)
-	suite.Equal(10000.4, cr[0].PricePoint.Price)
-	suite.Equal(50000.1234, cr[0].PricePoint.Volume)
-	suite.Equal(10000.4, cr[0].PricePoint.Bid)
-	suite.Equal(10000.5, cr[0].PricePoint.Ask)
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(int64(1596708166), pps[0].Timestamp)
+	suite.Equal(10000.4, pps[0].Price)
+	suite.Equal(50000.1234, pps[0].Volume)
+	suite.Equal(10000.4, pps[0].Bid)
+	suite.Equal(10000.5, pps[0].Ask)
 }
 
 func (suite *OkexSuite) TestRealAPICall() {

--- a/pkg/exchange/poloniex.go
+++ b/pkg/exchange/poloniex.go
@@ -53,9 +53,9 @@ func (p *Poloniex) getURL(pp *model.PricePoint) string {
 	return poloniexURL
 }
 
-func (p *Poloniex) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		p.callOne(ppp)
+func (p *Poloniex) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		p.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/poloniex.go
+++ b/pkg/exchange/poloniex.go
@@ -55,11 +55,11 @@ func (p *Poloniex) getURL(pp *model.PricePoint) string {
 
 func (p *Poloniex) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		p.callOne(pp)
+		p.fetchOne(pp)
 	}
 }
 
-func (p *Poloniex) callOne(pp *model.PricePoint) {
+func (p *Poloniex) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/poloniex.go
+++ b/pkg/exchange/poloniex.go
@@ -59,6 +59,7 @@ func (p *Poloniex) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (p *Poloniex) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {

--- a/pkg/exchange/poloniex_test.go
+++ b/pkg/exchange/poloniex_test.go
@@ -56,20 +56,16 @@ func (suite *PoloniexSuite) TestLocalPair() {
 }
 
 func (suite *PoloniexSuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("poloniex", "BTC", "ETH")
+	pp := newPricePoint("poloniex", "BTC", "ETH")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -77,90 +73,100 @@ func (suite *PoloniexSuite) TestFailOnWrongInput() {
 		Error: ourErr,
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(""),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte("{}"),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"BBB_EEE":{}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"ETH_BTC":{"last":"abc"}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"ETH_BTC":{"last":"1","lowestAsk":"abc"}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"ETH_BTC":{"last":"1","lowestAsk":"1","baseVolume":"abc"}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"ETH_BTC":{"last":"1","lowestAsk":"1","baseVolume":"1","highestBid":"abc"}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"BBB_ETT":{"last":"1","lowestAsk":"1","baseVolume":"1","highestBid":"1"}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 }
 
 func (suite *PoloniexSuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("poloniex", "BTC", "ETH")
+	pp := newPricePoint("poloniex", "BTC", "ETH")
 	resp := &query.HTTPResponse{
 		Body: []byte(`{"ETH_BTC":{"last":"1","lowestAsk":"2","baseVolume":"3","highestBid":"4"}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
 
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(1.0, cr[0].PricePoint.Price)
-	suite.Equal(2.0, cr[0].PricePoint.Ask)
-	suite.Equal(3.0, cr[0].PricePoint.Volume)
-	suite.Equal(4.0, cr[0].PricePoint.Bid)
-	suite.Greater(cr[0].PricePoint.Timestamp, int64(2))
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(1.0, pps[0].Price)
+	suite.Equal(2.0, pps[0].Ask)
+	suite.Equal(3.0, pps[0].Volume)
+	suite.Equal(4.0, pps[0].Bid)
+	suite.Greater(pps[0].Timestamp, int64(2))
 }
 
 func (suite *PoloniexSuite) TestRealAPICall() {

--- a/pkg/exchange/uniswap.go
+++ b/pkg/exchange/uniswap.go
@@ -71,11 +71,11 @@ func (u *Uniswap) getURL(_ *model.PricePoint) string {
 
 func (u *Uniswap) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		u.callOne(pp)
+		u.fetchOne(pp)
 	}
 }
 
-func (u *Uniswap) callOne(pp *model.PricePoint) {
+func (u *Uniswap) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/uniswap.go
+++ b/pkg/exchange/uniswap.go
@@ -69,9 +69,9 @@ func (u *Uniswap) getURL(_ *model.PricePoint) string {
 	return uniswapURL
 }
 
-func (u *Uniswap) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		u.callOne(ppp)
+func (u *Uniswap) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		u.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/uniswap.go
+++ b/pkg/exchange/uniswap.go
@@ -75,6 +75,7 @@ func (u *Uniswap) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (u *Uniswap) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {

--- a/pkg/exchange/uniswap_test.go
+++ b/pkg/exchange/uniswap_test.go
@@ -57,20 +57,16 @@ func (suite *UniswapSuite) TestLocalPair() {
 }
 
 func (suite *UniswapSuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("uniswap", "COMP", "ETH")
+	pp := newPricePoint("uniswap", "COMP", "ETH")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -78,74 +74,82 @@ func (suite *UniswapSuite) TestFailOnWrongInput() {
 		Error: ourErr,
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(""),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte("{}"),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"data":{}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"data":{"pairs":[]}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`{"data":{"pairs":[{}]}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 }
 
 func (suite *UniswapSuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("uniswap", "COMP", "ETH")
+	pp := newPricePoint("uniswap", "COMP", "ETH")
 	resp := &query.HTTPResponse{
 		Body: []byte(`{"data":{"pairs":[{"token0Price":"0", "token1Price":"1"}]}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(1.0, cr[0].PricePoint.Price)
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(1.0, pps[0].Price)
 }
 
 func (suite *UniswapSuite) TestSuccessResponseForToken0Price() {
-	pp := newPotentialPricePoint("uniswap", "KNC", "ETH")
+	pp := newPricePoint("uniswap", "KNC", "ETH")
 	resp := &query.HTTPResponse{
 		Body: []byte(`{"data":{"pairs":[{"token0Price":"1", "token1Price":"2"}]}}`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(1.0, cr[0].PricePoint.Price)
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(1.0, pps[0].Price)
 }
 
 func (suite *UniswapSuite) TestRealAPICall() {

--- a/pkg/exchange/upbit.go
+++ b/pkg/exchange/upbit.go
@@ -56,6 +56,7 @@ func (u *Upbit) Fetch(pps []*model.PricePoint) {
 	}
 }
 
+//nolint:funlen
 func (u *Upbit) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
@@ -88,9 +89,11 @@ func (u *Upbit) fetchOne(pp *model.PricePoint) {
 		pp.Error = fmt.Errorf("wrong upbit response: %s", res.Body)
 		return
 	}
-	data := resp[0]
 
+	const nanoseconds = 1000
+
+	data := resp[0]
 	pp.Price = data.Price
 	pp.Volume = data.Volume
-	pp.Timestamp = data.Timestamp / 1000
+	pp.Timestamp = data.Timestamp / nanoseconds
 }

--- a/pkg/exchange/upbit.go
+++ b/pkg/exchange/upbit.go
@@ -52,11 +52,11 @@ func (u *Upbit) getURL(pp *model.PricePoint) string {
 
 func (u *Upbit) Fetch(pps []*model.PricePoint) {
 	for _, pp := range pps {
-		u.callOne(pp)
+		u.fetchOne(pp)
 	}
 }
 
-func (u *Upbit) callOne(pp *model.PricePoint) {
+func (u *Upbit) fetchOne(pp *model.PricePoint) {
 	err := model.ValidatePricePoint(pp)
 	if err != nil {
 		pp.Error = err

--- a/pkg/exchange/upbit.go
+++ b/pkg/exchange/upbit.go
@@ -50,9 +50,9 @@ func (u *Upbit) getURL(pp *model.PricePoint) string {
 	return fmt.Sprintf(upbitURL, u.localPairName(pp.Pair))
 }
 
-func (u *Upbit) Fetch(ppps []*model.PricePoint) {
-	for _, ppp := range ppps {
-		u.callOne(ppp)
+func (u *Upbit) Fetch(pps []*model.PricePoint) {
+	for _, pp := range pps {
+		u.callOne(pp)
 	}
 }
 

--- a/pkg/exchange/upbit_test.go
+++ b/pkg/exchange/upbit_test.go
@@ -56,20 +56,16 @@ func (suite *UpbitSuite) TestLocalPair() {
 }
 
 func (suite *UpbitSuite) TestFailOnWrongInput() {
-	// empty pp
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{nil})
-	suite.Len(cr, 1)
-	suite.Nil(cr[0].PricePoint)
-	suite.Error(cr[0].Error)
-
 	// wrong pp
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{{}})
-	suite.Error(cr[0].Error)
+	pps := []*model.PricePoint{{}}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
-	pp := newPotentialPricePoint("upbit", "BTC", "ETH")
+	pp := newPricePoint("upbit", "BTC", "ETH")
 	// nil as response
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(errEmptyExchangeResponse, pps[0].Error)
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -77,55 +73,61 @@ func (suite *UpbitSuite) TestFailOnWrongInput() {
 		Error: ourErr,
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Equal(ourErr, pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte(""),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{
 		Body: []byte("[]"),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`[{"trade_price":"abc"}]`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 
 	// Error parsing
 	resp = &query.HTTPResponse{
 		Body: []byte(`[{"trade_price":1,"acc_trade_volume":"abc"}]`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Error(cr[0].Error)
+	pps = []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.Error(pps[0].Error)
 }
 
 func (suite *UpbitSuite) TestSuccessResponse() {
-	pp := newPotentialPricePoint("upbit", "BTC", "ETH")
+	pp := newPricePoint("upbit", "BTC", "ETH")
 	resp := &query.HTTPResponse{
 		Body: []byte(`[{"trade_price":1,"acc_trade_volume":3,"timestamp":2000}]`),
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
-	cr := suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.NoError(cr[0].Error)
-	suite.Equal(pp.Exchange, cr[0].PricePoint.Exchange)
-	suite.Equal(pp.Pair, cr[0].PricePoint.Pair)
-	suite.Equal(1.0, cr[0].PricePoint.Price)
-	suite.Equal(3.0, cr[0].PricePoint.Volume)
-	suite.Equal(cr[0].PricePoint.Timestamp, int64(2))
+	pps := []*model.PricePoint{pp}
+	suite.exchange.Fetch(pps)
+	suite.NoError(pps[0].Error)
+	suite.Equal(pp.Exchange, pps[0].Exchange)
+	suite.Equal(pp.Pair, pps[0].Pair)
+	suite.Equal(1.0, pps[0].Price)
+	suite.Equal(3.0, pps[0].Volume)
+	suite.Equal(pps[0].Timestamp, int64(2))
 }
 
 func (suite *UpbitSuite) TestRealAPICall() {

--- a/pkg/exchange/utils_test.go
+++ b/pkg/exchange/utils_test.go
@@ -33,12 +33,12 @@ type Suite interface {
 	Exchange() Handler
 }
 
-func newPotentialPricePoint(exchangeName, base, quote string) *model.PotentialPricePoint {
+func newPricePoint(exchangeName, base, quote string) *model.PricePoint {
 	p := &model.Pair{
 		Base:  base,
 		Quote: quote,
 	}
-	return &model.PotentialPricePoint{
+	return &model.PricePoint{
 		Exchange: &model.Exchange{
 			Name: exchangeName,
 		},
@@ -53,9 +53,10 @@ func testRealAPICall(suite Suite, exchange Handler, base, quote string) {
 
 	suite.Assert().IsType(suite.Exchange(), exchange)
 
-	ppp := newPotentialPricePoint("exchange", base, quote)
-	cr := exchange.Call([]*model.PotentialPricePoint{ppp})
+	ppp := newPricePoint("exchange", base, quote)
+	pps := []*model.PricePoint{ppp}
+	exchange.Fetch(pps)
 
-	suite.Assert().NoError(cr[0].Error)
-	suite.Assert().Greater(cr[0].PricePoint.Price, float64(0))
+	suite.Assert().NoError(pps[0].Error)
+	suite.Assert().Greater(pps[0].Price, float64(0))
 }

--- a/pkg/exchange/utils_test.go
+++ b/pkg/exchange/utils_test.go
@@ -53,8 +53,8 @@ func testRealAPICall(suite Suite, exchange Handler, base, quote string) {
 
 	suite.Assert().IsType(suite.Exchange(), exchange)
 
-	ppp := newPricePoint("exchange", base, quote)
-	pps := []*model.PricePoint{ppp}
+	pp := newPricePoint("exchange", base, quote)
+	pps := []*model.PricePoint{pp}
 	exchange.Fetch(pps)
 
 	suite.Assert().NoError(pps[0].Error)

--- a/pkg/gofer/gofer.go
+++ b/pkg/gofer/gofer.go
@@ -99,8 +99,8 @@ func (g *Gofer) Prices(pairs ...*model.Pair) (map[model.Pair]*model.PriceAggrega
 func (g *Gofer) Exchanges(pairs ...*model.Pair) []*model.Exchange {
 	exchanges := make(map[string]*model.Exchange)
 
-	for _, ppp := range g.aggregator.GetSources(pairs...) {
-		exchanges[ppp.Exchange.Name] = ppp.Exchange
+	for _, pp := range g.aggregator.GetSources(pairs...) {
+		exchanges[pp.Exchange.Name] = pp.Exchange
 	}
 
 	result := make([]*model.Exchange, 0)
@@ -114,8 +114,8 @@ func (g *Gofer) Exchanges(pairs ...*model.Pair) []*model.Exchange {
 func (g *Gofer) Pairs() []*model.Pair {
 	pairs := make(map[string]*model.Pair)
 
-	for _, ppp := range g.aggregator.GetSources() {
-		pairs[ppp.Pair.String()] = ppp.Pair
+	for _, pp := range g.aggregator.GetSources() {
+		pairs[pp.Pair.String()] = pp.Pair
 	}
 
 	result := make([]*model.Pair, 0)

--- a/pkg/gofer/gofer_test.go
+++ b/pkg/gofer/gofer_test.go
@@ -31,7 +31,7 @@ import (
 type GoferLibSuite struct {
 	suite.Suite
 	aggregator *aggregatorMock.Aggregator
-	sources    []*model.PotentialPricePoint
+	sources    []*model.PricePoint
 }
 
 func (suite *GoferLibSuite) TestGoferLibExchanges() {
@@ -79,8 +79,8 @@ func (suite *GoferLibSuite) TestGoferLibExchanges() {
 	assert.Len(t, exchanges, 0)
 }
 
-func newPotentialPricePoint(exchangeName string, pair *model.Pair) *model.PotentialPricePoint {
-	return &model.PotentialPricePoint{
+func newPricePoint(exchangeName string, pair *model.Pair) *model.PricePoint {
+	return &model.PricePoint{
 		Exchange: &model.Exchange{
 			Name: exchangeName,
 		},
@@ -90,11 +90,11 @@ func newPotentialPricePoint(exchangeName string, pair *model.Pair) *model.Potent
 
 // Runs before each test
 func (suite *GoferLibSuite) SetupTest() {
-	sources := []*model.PotentialPricePoint{
-		newPotentialPricePoint("exchange-a", model.NewPair("a", "b")),
-		newPotentialPricePoint("exchange-a", model.NewPair("a", "z")),
-		newPotentialPricePoint("exchange-b", model.NewPair("a", "z")),
-		newPotentialPricePoint("exchange-c", model.NewPair("b", "d")),
+	sources := []*model.PricePoint{
+		newPricePoint("exchange-a", model.NewPair("a", "b")),
+		newPricePoint("exchange-a", model.NewPair("a", "z")),
+		newPricePoint("exchange-b", model.NewPair("a", "z")),
+		newPricePoint("exchange-c", model.NewPair("b", "d")),
 	}
 	agg := &aggregatorMock.Aggregator{
 		Returns: map[model.Pair]*model.PriceAggregate{
@@ -109,18 +109,18 @@ func (suite *GoferLibSuite) SetupTest() {
 				},
 			},
 		},
-		Sources: map[model.Pair][]*model.PotentialPricePoint{
+		Sources: map[model.Pair][]*model.PricePoint{
 			*model.NewPair("a", "b"): {
-				newPotentialPricePoint("exchange-a", model.NewPair("a", "b")),
+				newPricePoint("exchange-a", model.NewPair("a", "b")),
 			},
 			*model.NewPair("a", "z"): {
-				newPotentialPricePoint("exchange-a", model.NewPair("a", "z")),
-				newPotentialPricePoint("exchange-b", model.NewPair("a", "z")),
+				newPricePoint("exchange-a", model.NewPair("a", "z")),
+				newPricePoint("exchange-b", model.NewPair("a", "z")),
 			},
 			*model.NewPair("b", "d"): {
-				newPotentialPricePoint("exchange-c", model.NewPair("b", "d")),
-				newPotentialPricePoint("exchange-d", model.NewPair("b", "c")),
-				newPotentialPricePoint("exchange-d", model.NewPair("d", "c")),
+				newPricePoint("exchange-c", model.NewPair("b", "d")),
+				newPricePoint("exchange-d", model.NewPair("b", "c")),
+				newPricePoint("exchange-d", model.NewPair("d", "c")),
 			},
 		},
 	}

--- a/pkg/gofer/integration_test.go
+++ b/pkg/gofer/integration_test.go
@@ -146,21 +146,21 @@ func TestSetzAggregatorIntegration(t *testing.T) {
 	}
 
 	gofer.fetcher = FetcherMock(pas)
-	ppps := gofer.aggregator.GetSources([]*model.Pair{model.NewPair("B", "C")}...)
+	pps := gofer.aggregator.GetSources([]*model.Pair{model.NewPair("B", "C")}...)
 
 	assert.ElementsMatch(t, []*model.PricePoint{
 		{Exchange: &model.Exchange{Name: "e-a"}, Pair: model.NewPair("b", "c")},
 		{Exchange: &model.Exchange{Name: "e-b"}, Pair: model.NewPair("b", "c")},
-	}, ppps)
+	}, pps)
 
-	ppps = gofer.aggregator.GetSources([]*model.Pair{model.NewPair("A", "C")}...)
+	pps = gofer.aggregator.GetSources([]*model.Pair{model.NewPair("A", "C")}...)
 
 	assert.ElementsMatch(t, []*model.PricePoint{
 		{Exchange: &model.Exchange{Name: "e-d"}, Pair: model.NewPair("a", "b")},
 		{Exchange: &model.Exchange{Name: "e-a"}, Pair: model.NewPair("b", "c")},
 		{Exchange: &model.Exchange{Name: "e-b"}, Pair: model.NewPair("b", "c")},
 		{Exchange: &model.Exchange{Name: "e-c", Config: map[string]string{"a": "1"}}, Pair: model.NewPair("a", "c")},
-	}, ppps)
+	}, pps)
 
 	for i := 0; i < 1; i++ {
 		res, err := gofer.Prices(

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -272,14 +272,14 @@ func ValidatePricePathMap(ppaths PricePathMap) error {
 }
 
 // String returns a string representation of PricePoint e.g. source[exchange](BTC/USD)
-func (ppp *PricePoint) String() string {
+func (pp *PricePoint) String() string {
 	var pair string
 	var exchange string
-	if ppp.Exchange != nil {
-		exchange = ppp.Exchange.Name
+	if pp.Exchange != nil {
+		exchange = pp.Exchange.Name
 	}
-	if ppp.Pair != nil {
-		pair = ppp.Pair.String()
+	if pp.Pair != nil {
+		pair = pp.Pair.String()
 	}
 	return fmt.Sprintf("source[%s](%s)", exchange, pair)
 }

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -41,25 +41,7 @@ type PricePoint struct {
 	Ask       float64   // Best ask price
 	Bid       float64   // Best bid price
 	Volume    float64   // Trade volume
-}
-
-// PotentialPricePoint represents PricePoint that should be fetched from Exchange
-type PotentialPricePoint struct {
-	Pair     *Pair
-	Exchange *Exchange
-}
-
-// String returns a string representation of `PotentialPricePoint` e.g. source[exchange](BTC/USD)
-func (ppp *PotentialPricePoint) String() string {
-	var pair string
-	var exchange string
-	if ppp.Exchange != nil {
-		exchange = ppp.Exchange.Name
-	}
-	if ppp.Pair != nil {
-		pair = ppp.Pair.String()
-	}
-	return fmt.Sprintf("source[%s](%s)", exchange, pair)
+	Error     error     // Optional error
 }
 
 // PriceAggregate price aggregation
@@ -186,15 +168,15 @@ func ValidatePair(p *Pair) error {
 	return nil
 }
 
-// ValidatePotentialPricePoint checks if given `PotentialPricePoint` is valid.
-// If it's valid no error will be returned, othervise some error.
-func ValidatePotentialPricePoint(pp *PotentialPricePoint) error {
+// ValidatePricePoint checks if given PricePoint is valid.
+// If it's valid no error will be returned, otherwise some error.
+func ValidatePricePoint(pp *PricePoint) error {
 	if pp == nil {
-		return fmt.Errorf("given PotentialPricePoint is nil")
+		return fmt.Errorf("given PricePoint is nil")
 	}
 	err := ValidateExchange(pp.Exchange)
 	if err != nil {
-		return fmt.Errorf("given PotentialPricePoint has wrong exchange: %w", err)
+		return fmt.Errorf("given PricePoint has wrong exchange: %w", err)
 	}
 	return ValidatePair(pp.Pair)
 }
@@ -287,6 +269,19 @@ func ValidatePricePathMap(ppaths PricePathMap) error {
 		}
 	}
 	return nil
+}
+
+// String returns a string representation of PricePoint e.g. source[exchange](BTC/USD)
+func (ppp *PricePoint) String() string {
+	var pair string
+	var exchange string
+	if ppp.Exchange != nil {
+		exchange = ppp.Exchange.Name
+	}
+	if ppp.Pair != nil {
+		pair = ppp.Pair.String()
+	}
+	return fmt.Sprintf("source[%s](%s)", exchange, pair)
 }
 
 // String returns PricePath string representation

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -65,23 +65,23 @@ func (suite *ModelSuite) TestValidatePair() {
 	assert.NoError(suite.T(), ValidatePair(&Pair{Base: "ETH", Quote: "BTC"}))
 }
 
-func (suite *ModelSuite) TestValidatePotentialPricePoint() {
+func (suite *ModelSuite) TestValidatePricePoint() {
 	p := &Pair{Base: "BTC", Quote: "ETH"}
 	ex := &Exchange{Name: "test"}
-	pp := &PotentialPricePoint{Pair: p, Exchange: ex}
+	pp := &PricePoint{Pair: p, Exchange: ex}
 
-	assert.Error(suite.T(), ValidatePotentialPricePoint(nil))
-	assert.Error(suite.T(), ValidatePotentialPricePoint(&PotentialPricePoint{}))
+	assert.Error(suite.T(), ValidatePricePoint(nil))
+	assert.Error(suite.T(), ValidatePricePoint(&PricePoint{}))
 
-	assert.Error(suite.T(), ValidatePotentialPricePoint(&PotentialPricePoint{Pair: p}))
-	assert.Error(suite.T(), ValidatePotentialPricePoint(&PotentialPricePoint{Pair: &Pair{}}))
-	assert.Error(suite.T(), ValidatePotentialPricePoint(&PotentialPricePoint{Pair: &Pair{Base: "BTC"}}))
-	assert.Error(suite.T(), ValidatePotentialPricePoint(&PotentialPricePoint{Pair: &Pair{Quote: "BTC"}}))
+	assert.Error(suite.T(), ValidatePricePoint(&PricePoint{Pair: p}))
+	assert.Error(suite.T(), ValidatePricePoint(&PricePoint{Pair: &Pair{}}))
+	assert.Error(suite.T(), ValidatePricePoint(&PricePoint{Pair: &Pair{Base: "BTC"}}))
+	assert.Error(suite.T(), ValidatePricePoint(&PricePoint{Pair: &Pair{Quote: "BTC"}}))
 
-	assert.Error(suite.T(), ValidatePotentialPricePoint(&PotentialPricePoint{Exchange: ex}))
-	assert.Error(suite.T(), ValidatePotentialPricePoint(&PotentialPricePoint{Pair: p, Exchange: &Exchange{}}))
+	assert.Error(suite.T(), ValidatePricePoint(&PricePoint{Exchange: ex}))
+	assert.Error(suite.T(), ValidatePricePoint(&PricePoint{Pair: p, Exchange: &Exchange{}}))
 
-	assert.NoError(suite.T(), ValidatePotentialPricePoint(pp))
+	assert.NoError(suite.T(), ValidatePricePoint(pp))
 }
 
 func (suite *ModelSuite) TestPricePathTarget() {


### PR DESCRIPTION
This PR replaces all `PotentialPricePoint`s to `PricePoint`s, adds the `Error` field to the `PricePoint`, and removes the `CallResult`. 

I made this PR because converting many PPPs to PP has become difficult in `Fetcher`s, especially with proper error handling. Without this PR we'll need to write a lot of repetitive code for that conversion in all exchange implementations.