### PR TITLE
Proposal: example of adding PotentialPricePoint in CallResult error

### DIFF
--- a/pkg/exchange/binance.go
+++ b/pkg/exchange/binance.go
@@ -51,14 +51,7 @@ func (b *Binance) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (b *Binance) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := b.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(b, ppps)
 }
 
 func (b *Binance) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/binance_test.go
+++ b/pkg/exchange/binance_test.go
@@ -69,7 +69,7 @@ func (suite *BinanceSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("binance", "BTC", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -79,7 +79,7 @@ func (suite *BinanceSuite) TestFailOnWrongInput() {
 
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{

--- a/pkg/exchange/bitfinex.go
+++ b/pkg/exchange/bitfinex.go
@@ -59,14 +59,7 @@ func (b *Bitfinex) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (b *Bitfinex) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := b.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(b, ppps)
 }
 
 func (b *Bitfinex) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/bitfinex_test.go
+++ b/pkg/exchange/bitfinex_test.go
@@ -70,7 +70,7 @@ func (suite *BitfinexSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("bitfinex", "BTC", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -79,7 +79,7 @@ func (suite *BitfinexSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{

--- a/pkg/exchange/bitstamp.go
+++ b/pkg/exchange/bitstamp.go
@@ -54,14 +54,7 @@ func (b *Bitstamp) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (b *Bitstamp) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := b.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(b, ppps)
 }
 
 func (b *Bitstamp) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/bitstamp_test.go
+++ b/pkg/exchange/bitstamp_test.go
@@ -69,7 +69,7 @@ func (suite *BitstampSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("bitstamp", "BTC", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -78,7 +78,7 @@ func (suite *BitstampSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{

--- a/pkg/exchange/bittrex.go
+++ b/pkg/exchange/bittrex.go
@@ -51,14 +51,7 @@ func (b *BitTrex) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (b *BitTrex) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := b.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(b, ppps)
 }
 
 func (b *BitTrex) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/bittrex_test.go
+++ b/pkg/exchange/bittrex_test.go
@@ -69,7 +69,7 @@ func (suite *BitTrexSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("bittrex", "BTC", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -78,7 +78,7 @@ func (suite *BitTrexSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{

--- a/pkg/exchange/coinbase.go
+++ b/pkg/exchange/coinbase.go
@@ -50,14 +50,7 @@ func (c *Coinbase) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (c *Coinbase) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := c.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(c, ppps)
 }
 
 func (c *Coinbase) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/coinbase_test.go
+++ b/pkg/exchange/coinbase_test.go
@@ -69,7 +69,7 @@ func (suite *CoinbaseSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("coinbase", "BTC", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -78,7 +78,7 @@ func (suite *CoinbaseSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{

--- a/pkg/exchange/coinbasepro.go
+++ b/pkg/exchange/coinbasepro.go
@@ -50,14 +50,7 @@ func (c *CoinbasePro) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (c *CoinbasePro) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := c.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(c, ppps)
 }
 
 func (c *CoinbasePro) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/coinbasepro_test.go
+++ b/pkg/exchange/coinbasepro_test.go
@@ -69,7 +69,7 @@ func (suite *CoinbaseProSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("coinbasepro", "BTC", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -78,7 +78,7 @@ func (suite *CoinbaseProSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{

--- a/pkg/exchange/cryptocompare.go
+++ b/pkg/exchange/cryptocompare.go
@@ -39,14 +39,7 @@ func (c *CryptoCompare) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (c *CryptoCompare) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := c.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(c, ppps)
 }
 
 func (c *CryptoCompare) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/cryptocompare_test.go
+++ b/pkg/exchange/cryptocompare_test.go
@@ -64,7 +64,7 @@ func (suite *CryptoCompareSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("cryptocompare", "BTC", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -73,7 +73,7 @@ func (suite *CryptoCompareSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	for n, r := range [][]byte{
 		// invalid response

--- a/pkg/exchange/ddex.go
+++ b/pkg/exchange/ddex.go
@@ -58,14 +58,7 @@ func (d *Ddex) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (d *Ddex) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := d.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(d, ppps)
 }
 
 func (d *Ddex) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/ddex_test.go
+++ b/pkg/exchange/ddex_test.go
@@ -69,7 +69,7 @@ func (suite *DdexSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("ddex", "BTC", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -78,7 +78,7 @@ func (suite *DdexSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{

--- a/pkg/exchange/exchanges_test.go
+++ b/pkg/exchange/exchanges_test.go
@@ -54,7 +54,8 @@ func (suite *ExchangesSuite) TestCallErrorNegative() {
 		Exchange: ex,
 	}
 	cr = suite.set.Call([]*model.PotentialPricePoint{pp})
-	assert.Same(suite.T(), ex, cr[0].PricePoint.Exchange)
+	assert.Nil(suite.T(), cr[0].PricePoint)
+	assert.Same(suite.T(), ex, cr[0].Error.(*CallError).PotentialPricePoint.Exchange)
 	assert.Error(suite.T(), cr[0].Error)
 }
 

--- a/pkg/exchange/folgory.go
+++ b/pkg/exchange/folgory.go
@@ -49,13 +49,7 @@ func (f *Folgory) localPairName(pair *model.Pair) string {
 }
 
 func (f *Folgory) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := f.callOne(ppp)
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(f, ppps)
 }
 
 func (f *Folgory) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/folgory_test.go
+++ b/pkg/exchange/folgory_test.go
@@ -69,7 +69,7 @@ func (suite *FolgorySuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("folgory", "BTC", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -78,7 +78,7 @@ func (suite *FolgorySuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{

--- a/pkg/exchange/ftx.go
+++ b/pkg/exchange/ftx.go
@@ -52,13 +52,7 @@ func (f *Ftx) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (f *Ftx) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := f.callOne(ppp)
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(f, ppps)
 }
 
 func (f *Ftx) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/ftx_test.go
+++ b/pkg/exchange/ftx_test.go
@@ -69,7 +69,7 @@ func (suite *FtxSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("ftx", "BTC", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -78,7 +78,7 @@ func (suite *FtxSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	for n, r := range [][]byte{
 		// invalid response

--- a/pkg/exchange/fx.go
+++ b/pkg/exchange/fx.go
@@ -50,13 +50,7 @@ func (f *Fx) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (f *Fx) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := f.callOne(ppp)
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(f, ppps)
 }
 
 func (f *Fx) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/fx_test.go
+++ b/pkg/exchange/fx_test.go
@@ -68,7 +68,7 @@ func (suite *FxSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("fx", "BTC", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -77,7 +77,7 @@ func (suite *FxSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{

--- a/pkg/exchange/gateio.go
+++ b/pkg/exchange/gateio.go
@@ -59,14 +59,7 @@ func (g *Gateio) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (g *Gateio) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := g.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(g, ppps)
 }
 
 func (g *Gateio) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/gateio_test.go
+++ b/pkg/exchange/gateio_test.go
@@ -69,7 +69,7 @@ func (suite *GateioSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("gateio", "BTC", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -78,7 +78,7 @@ func (suite *GateioSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{

--- a/pkg/exchange/gemini.go
+++ b/pkg/exchange/gemini.go
@@ -51,14 +51,7 @@ func (g *Gemini) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (g *Gemini) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := g.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(g, ppps)
 }
 
 func (g *Gemini) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/gemini_test.go
+++ b/pkg/exchange/gemini_test.go
@@ -69,7 +69,7 @@ func (suite *GeminiSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("gemini", "BTC", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -78,7 +78,7 @@ func (suite *GeminiSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{

--- a/pkg/exchange/hitbtc.go
+++ b/pkg/exchange/hitbtc.go
@@ -51,14 +51,7 @@ func (h *Hitbtc) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (h *Hitbtc) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := h.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(h, ppps)
 }
 
 func (h *Hitbtc) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/hitbtc_test.go
+++ b/pkg/exchange/hitbtc_test.go
@@ -69,7 +69,7 @@ func (suite *HitbtcSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("hitbtc", "BTC", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -78,7 +78,7 @@ func (suite *HitbtcSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{

--- a/pkg/exchange/huobi.go
+++ b/pkg/exchange/huobi.go
@@ -50,14 +50,7 @@ func (h *Huobi) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (h *Huobi) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := h.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(h, ppps)
 }
 
 func (h *Huobi) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/huobi_test.go
+++ b/pkg/exchange/huobi_test.go
@@ -69,7 +69,7 @@ func (suite *HuobiSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("huobi", "BTC", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -78,7 +78,7 @@ func (suite *HuobiSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{

--- a/pkg/exchange/kraken.go
+++ b/pkg/exchange/kraken.go
@@ -104,14 +104,7 @@ func (k *Kraken) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (k *Kraken) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := k.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(k, ppps)
 }
 
 func (k *Kraken) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/kraken_test.go
+++ b/pkg/exchange/kraken_test.go
@@ -69,7 +69,7 @@ func (suite *KrakenSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("kraken", "DAI", "USD")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -78,7 +78,7 @@ func (suite *KrakenSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{

--- a/pkg/exchange/kucoin.go
+++ b/pkg/exchange/kucoin.go
@@ -51,14 +51,7 @@ func (k *Kucoin) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (k *Kucoin) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := k.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(k, ppps)
 }
 
 func (k *Kucoin) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/kucoin_test.go
+++ b/pkg/exchange/kucoin_test.go
@@ -69,7 +69,7 @@ func (suite *KucoinSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("kucoin", "BTC", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -78,7 +78,7 @@ func (suite *KucoinSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{

--- a/pkg/exchange/kyber.go
+++ b/pkg/exchange/kyber.go
@@ -62,14 +62,7 @@ func (k *Kyber) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (k *Kyber) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := k.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(k, ppps)
 }
 
 func (k *Kyber) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/kyber_test.go
+++ b/pkg/exchange/kyber_test.go
@@ -67,7 +67,7 @@ func (suite *KyberSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("kyber", "WBTC", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -76,7 +76,7 @@ func (suite *KyberSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{

--- a/pkg/exchange/loopring.go
+++ b/pkg/exchange/loopring.go
@@ -58,14 +58,7 @@ func (l *Loopring) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (l *Loopring) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := l.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(l, ppps)
 }
 
 func (l *Loopring) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/loopring_test.go
+++ b/pkg/exchange/loopring_test.go
@@ -100,7 +100,7 @@ func (suite *LoopringSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("loopring", "LRC", "USDT")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -109,7 +109,7 @@ func (suite *LoopringSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{

--- a/pkg/exchange/okex.go
+++ b/pkg/exchange/okex.go
@@ -58,14 +58,7 @@ func (o *Okex) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (o *Okex) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := o.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(o, ppps)
 }
 
 func (o *Okex) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/okex_test.go
+++ b/pkg/exchange/okex_test.go
@@ -69,7 +69,7 @@ func (suite *OkexSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("okex", "BTC", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -78,7 +78,7 @@ func (suite *OkexSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{

--- a/pkg/exchange/poloniex.go
+++ b/pkg/exchange/poloniex.go
@@ -54,14 +54,7 @@ func (p *Poloniex) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (p *Poloniex) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := p.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(p, ppps)
 }
 
 func (p *Poloniex) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/poloniex_test.go
+++ b/pkg/exchange/poloniex_test.go
@@ -69,7 +69,7 @@ func (suite *PoloniexSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("poloniex", "BTC", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -78,7 +78,7 @@ func (suite *PoloniexSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{

--- a/pkg/exchange/uniswap.go
+++ b/pkg/exchange/uniswap.go
@@ -70,14 +70,7 @@ func (u *Uniswap) getURL(_ *model.PotentialPricePoint) string {
 }
 
 func (u *Uniswap) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := u.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(u, ppps)
 }
 
 func (u *Uniswap) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/uniswap_test.go
+++ b/pkg/exchange/uniswap_test.go
@@ -70,7 +70,7 @@ func (suite *UniswapSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("uniswap", "COMP", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -79,7 +79,7 @@ func (suite *UniswapSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{

--- a/pkg/exchange/upbit.go
+++ b/pkg/exchange/upbit.go
@@ -51,14 +51,7 @@ func (u *Upbit) getURL(pp *model.PotentialPricePoint) string {
 }
 
 func (u *Upbit) Call(ppps []*model.PotentialPricePoint) []CallResult {
-	cr := make([]CallResult, 0)
-	for _, ppp := range ppps {
-		pp, err := u.callOne(ppp)
-
-		cr = append(cr, CallResult{PricePoint: pp, Error: err})
-	}
-
-	return cr
+	return callSinglePairExchange(u, ppps)
 }
 
 func (u *Upbit) callOne(pp *model.PotentialPricePoint) (*model.PricePoint, error) {

--- a/pkg/exchange/upbit_test.go
+++ b/pkg/exchange/upbit_test.go
@@ -69,7 +69,7 @@ func (suite *UpbitSuite) TestFailOnWrongInput() {
 	pp := newPotentialPricePoint("upbit", "BTC", "ETH")
 	// nil as response
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(errEmptyExchangeResponse, cr[0].Error)
+	suite.Equal(errEmptyExchangeResponse, cr[0].Error.(*CallError).Unwrap())
 
 	// error in response
 	ourErr := fmt.Errorf("error")
@@ -78,7 +78,7 @@ func (suite *UpbitSuite) TestFailOnWrongInput() {
 	}
 	suite.exchange.Pool.(*query.MockWorkerPool).MockResp(resp)
 	cr = suite.exchange.Call([]*model.PotentialPricePoint{pp})
-	suite.Equal(ourErr, cr[0].Error)
+	suite.Equal(ourErr, cr[0].Error.(*CallError).Unwrap())
 
 	// Error unmarshal
 	resp = &query.HTTPResponse{


### PR DESCRIPTION
Closes #64.

Instead of combining error information into `PricePoint` we can add specific call information to the error of `CallResult` instead (`CallError`).