### PR TITLE
Controll real API calls tests by ENV var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
       - run:
           name: Run unit tests
           command: |
-            gotestsum --junitfile /tmp/test-results/gotestsum-report.xml -- ./pkg/exchange/... -testify.m TestRealAPICall -gofer.test-api-calls=1
+            GOFER_TEST_API_CALLS=1 gotestsum --junitfile /tmp/test-results/gotestsum-report.xml -- ./pkg/exchange/... -testify.m TestRealAPICall
 
       - store_artifacts:
           path: /tmp/test-results

--- a/pkg/origins/utils_test.go
+++ b/pkg/origins/utils_test.go
@@ -16,13 +16,11 @@
 package origins
 
 import (
-	"flag"
+	"os"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
-
-var testAPICalls = flag.Bool("gofer.test-api-calls", false, "enable tests on real origins API")
 
 type Suite interface {
 	suite.TestingSuite
@@ -32,7 +30,7 @@ type Suite interface {
 }
 
 func testRealAPICall(suite Suite, origin Handler, base, quote string) {
-	if !*testAPICalls {
+	if os.Getenv("GOFER_TEST_API_CALLS") == "" {
 		suite.T().SkipNow()
 	}
 
@@ -46,7 +44,7 @@ func testRealAPICall(suite Suite, origin Handler, base, quote string) {
 }
 
 func testRealBatchAPICall(suite Suite, origin Handler, pairs []Pair) {
-	if !*testAPICalls {
+	if os.Getenv("GOFER_TEST_API_CALLS") == "" {
 		suite.T().SkipNow()
 	}
 


### PR DESCRIPTION
I reverted back to the previous solution with ENV var. It's much easier to work with ENV var because Go throws an error when the flag is used with tests outside the `origin` package.