### PR TITLE
Update Uniswap Handler to query for the actual pairs

### DIFF
--- a/gofer.json
+++ b/gofer.json
@@ -14,7 +14,7 @@
       "sources": [
         [{ "origin": "binance", "pair": "BAT/BTC" },{ "origin": ".", "pair": "BTC/USD" }],
         [{ "origin": "bittrex", "pair": "BAT/BTC" },{ "origin": ".", "pair": "BTC/USD" }],
-        [{ "origin": "coinbase", "pair": "BAT/USDC" }],
+        [{ "origin": "coinbase", "pair": "BAT/USD" }],
         [{ "origin": "upbit", "pair": "BAT/KRW" },{ "origin": "fx", "pair": "KRW/USD" }]
       ],
       "params": {
@@ -38,9 +38,10 @@
       "method": "median",
       "sources": [
         [{ "origin": "binance", "pair": "COMP/USDT" },{ "origin": ".", "pair": "USDT/USD" }],
-        [{ "origin": "okex", "pair": "COMP/USDT" },{ "origin": ".", "pair": "USDT/USD" }],
+        [{ "origin": "huobi", "pair": "COMP/USDT" },{ "origin": ".", "pair": "USDT/USD" }],
         [{ "origin": "kucoin", "pair": "COMP/USDT" },{ "origin": ".", "pair": "USDT/USD" }],
         [{ "origin": "coinbase", "pair": "COMP/USD" }],
+        [{ "origin": "kraken", "pair": "COMP/USD" }],
         [{ "origin": "uniswap", "pair": "COMP/ETH" },{ "origin": ".", "pair": "ETH/USD" }]
       ],
       "params": {
@@ -74,8 +75,8 @@
         [{ "origin": "bitfinex", "pair": "ETH/BTC" }],
         [{ "origin": "coinbase", "pair": "ETH/BTC" }],
         [{ "origin": "huobi", "pair": "ETH/BTC" }],
-        [{ "origin": "kraken", "pair": "ETH/BTC" }],
-        [{ "origin": "poloniex", "pair": "ETH/BTC" }]
+        [{ "origin": "poloniex", "pair": "ETH/BTC" }],
+        [{ "origin": "kraken", "pair": "ETH/BTC" }]
       ],
       "params": {
         "minimumSuccessfulSources": 4
@@ -85,11 +86,12 @@
       "method": "median",
       "sources": [
         [{ "origin": "binance", "pair": "ETH/BTC" },{ "origin": ".", "pair": "BTC/USD" }],
-        [{ "origin": "bitfinex", "pair": "ETH/USD" }],
         [{ "origin": "bitstamp", "pair": "ETH/USD" }],
         [{ "origin": "coinbase", "pair": "ETH/USD" }],
+        [{ "origin": "ftx", "pair": "ETH/USD" }],
         [{ "origin": "gemini", "pair": "ETH/USD" }],
-        [{ "origin": "kraken", "pair": "ETH/USD" }]
+        [{ "origin": "kraken", "pair": "ETH/USD" }],
+        [{ "origin": "uniswap", "pair": "ETH/USD" }]
       ],
       "params": {
         "minimumSuccessfulSources": 4
@@ -115,6 +117,7 @@
         [{ "origin": "huobi", "pair": "KNC/BTC" },{ "origin": ".", "pair": "ETH/BTC" }],
         [{ "origin": "coinbase", "pair": "KNC/USD" },{ "origin": ".", "pair": "ETH/USD" }],
         [{ "origin": "kyber", "pair": "KNC/ETH" }],
+        [{ "origin": "uniswap", "pair": "KNC/ETH" }],
         [{ "origin": "upbit", "pair": "KNC/KRW" },{ "origin": "upbit", "pair": "ETH/KRW" }]
       ],
       "params": {
@@ -138,7 +141,10 @@
       "method": "median",
       "sources": [
         [{ "origin": "binance", "pair": "LEND/BTC" },{ "origin": ".", "pair": "BTC/USD" }],
-        [{ "origin": "kyber", "pair": "LEND/ETH"},{ "origin": ".", "pair": "ETH/USD" }]
+        [{ "origin": "huobi", "pair": "LEND/USDT" },{ "origin": ".", "pair": "USDT/USD" }],
+        [{ "origin": "okex", "pair": "LEND/USDT" },{ "origin": ".", "pair": "USDT/USD" }],
+        [{ "origin": "kyber", "pair": "LEND/ETH"},{ "origin": ".", "pair": "ETH/USD" }],
+        [{ "origin": "uniswap", "pair": "LEND/ETH"},{ "origin": ".", "pair": "ETH/USD" }]
       ],
       "params": {
         "minimumSuccessfulSources": 3
@@ -151,7 +157,7 @@
         [{ "origin": "coinbase", "pair": "LINK/USD" }],
         [{ "origin": "gemini", "pair": "LINK/USD" }],
         [{ "origin": "huobi", "pair": "LINK/USDT" },{ "origin": ".", "pair": "USDT/USD" }],
-        [{ "origin": "kraken", "pair": "LINK/ETH" }]
+        [{ "origin": "kraken", "pair": "LINK/USD" }]
       ],
       "params": {
         "minimumSuccessfulSources": 3
@@ -162,8 +168,8 @@
       "sources": [
         [{ "origin": "binance", "pair": "LRC/BTC" },{ "origin": ".", "pair": "BTC/USD" }],
         [{ "origin": "gateio", "pair": "LRC/USDT" },{ "origin": ".", "pair": "USDT/USD" }],
-        [{ "origin": "loopring", "pair": "LRC/ETH" },{ "origin": ".", "pair": "ETH/USD" }],
         [{ "origin": "okex", "pair": "LRC/USDT" },{ "origin": ".", "pair": "USDT/USD" }],
+        [{ "origin": "loopring", "pair": "LRC/ETH" },{ "origin": ".", "pair": "ETH/USD" }],
         [{ "origin": "uniswap", "pair": "LRC/ETH" },{ "origin": ".", "pair": "ETH/USD" }]
       ],
       "params": {
@@ -205,6 +211,19 @@
       ],
       "params": {
         "minimumSuccessfulSources": 3
+      }
+    },
+    "PAXG/USD": {
+      "method": "median",
+      "sources": [
+        [{ "origin": "binance", "pair": "PAXG/USDT" },{ "origin": ".", "pair": "USDT/USD" }],
+        [{ "origin": "bitthumb", "pair": "PAXG/USDT" },{ "origin": ".", "pair": "USDT/USD" }],
+        [{ "origin": "gemini", "pair": "PAXG/USD" }],
+        [{ "origin": "kraken", "pair": "PAXG/USD" }],
+        [{ "origin": "uniswap", "pair": "PAXG/ETH" },{ "origin": ".", "pair": "ETH/USD" }]
+      ],
+      "params": {
+        "minimumSuccessfulSources": 2
       }
     },
     "POLY/USD": {
@@ -259,14 +278,27 @@
       "method": "median",
       "sources": [
         [{ "origin": "binance", "pair": "BTC/USDT" },{ "origin": ".", "pair": "BTC/USD" }],
+        [{ "origin": "okex", "pair": "BTC/USDT" },{ "origin": ".", "pair": "BTC/USD" }],
         [{ "origin": "bitfinex", "pair": "USDT/USD" }],
-        [{ "origin": "huobi", "pair": "ETH/USDT" },{ "origin": ".", "pair": "ETH/USD" }],
         [{ "origin": "ftx", "pair": "ETH/USDT" },{ "origin": ".", "pair": "ETH/USD" }],
-        [{ "origin": "kraken", "pair": "USDT/USD" }],
-        [{ "origin": "okex", "pair": "BTC/USDT" },{ "origin": ".", "pair": "BTC/USD" }]
+        [{ "origin": "huobi", "pair": "ETH/USDT" },{ "origin": ".", "pair": "ETH/USD" }],
+        [{ "origin": "kraken", "pair": "USDT/USD" }]
       ],
       "params": {
         "minimumSuccessfulSources": 3
+      }
+    },
+    "YFI/USD": {
+      "method": "median",
+      "sources": [
+        [{ "origin": "binance", "pair": "YFI/USDT" },{ "origin": ".", "pair": "USDT/USD" }],
+        [{ "origin": "huobi", "pair": "YFI/USDT" },{ "origin": ".", "pair": "USDT/USD" }],
+        [{ "origin": "coinbase", "pair": "YFI/USD" }],
+        [{ "origin": "ftx", "pair": "YFI/USD" }],
+        [{ "origin": "uniswap", "pair": "YFI/ETH" },{ "origin": ".", "pair": "ETH/USD" }]
+      ],
+      "params": {
+        "minimumSuccessfulSources": 2
       }
     },
     "WBTC/USD": {

--- a/pkg/origins/bitfinex.go
+++ b/pkg/origins/bitfinex.go
@@ -178,6 +178,7 @@ func (*Bitfinex) localPairName(pairs ...Pair) string {
 		}
 		// Hack to treat prices with USD quotes from Bitfinex as if they were with USDT quotes
 		if pair.Quote == "USDT" {
+			//nolint:goconst
 			q = "USD"
 		}
 		l = append(l, fmt.Sprintf("t%s%s", b, q))

--- a/pkg/origins/coinbase.go
+++ b/pkg/origins/coinbase.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/makerdao/gofer/internal/query"
@@ -42,8 +41,16 @@ type Coinbase struct {
 	Pool query.WorkerPool
 }
 
+// TODO: We should find better solution for this.
+func (c *Coinbase) renameSymbol(symbol string) string {
+	if symbol == "USD" {
+		return "USDC"
+	}
+	return symbol
+}
+
 func (c *Coinbase) localPairName(pair Pair) string {
-	return fmt.Sprintf("%s-%s", strings.ToUpper(pair.Base), strings.ToUpper(pair.Quote))
+	return fmt.Sprintf("%s-%s", c.renameSymbol(pair.Base), c.renameSymbol(pair.Quote))
 }
 
 func (c *Coinbase) getURL(pair Pair) string {

--- a/pkg/origins/coinbase_test.go
+++ b/pkg/origins/coinbase_test.go
@@ -51,7 +51,7 @@ func (suite *CoinbaseSuite) TearDownTest() {
 
 func (suite *CoinbaseSuite) TestLocalPair() {
 	suite.EqualValues("BTC-ETH", suite.origin.localPairName(Pair{Base: "BTC", Quote: "ETH"}))
-	suite.EqualValues("BTC-USD", suite.origin.localPairName(Pair{Base: "BTC", Quote: "USD"}))
+	suite.EqualValues("BTC-USDC", suite.origin.localPairName(Pair{Base: "BTC", Quote: "USD"}))
 }
 
 func (suite *CoinbaseSuite) TestFailOnWrongInput() {

--- a/pkg/origins/marshaling.go
+++ b/pkg/origins/marshaling.go
@@ -21,7 +21,6 @@ import (
 	"time"
 )
 
-//nolint:unused
 type stringAsFloat64 float64
 
 func (s *stringAsFloat64) UnmarshalJSON(bytes []byte) error {
@@ -113,7 +112,6 @@ func (s *intAsUnixTimestamp) val() time.Time {
 	return time.Time(*s)
 }
 
-//nolint:unused
 type intAsUnixTimestampMs time.Time
 
 func (s *intAsUnixTimestampMs) UnmarshalJSON(bytes []byte) error {

--- a/pkg/origins/uniswap.go
+++ b/pkg/origins/uniswap.go
@@ -47,7 +47,6 @@ type uniswapPairResponse struct {
 	Token1  uniswapTokenResponse `json:"token1"`
 }
 
-// Uniswap origin handler
 type Uniswap struct {
 	Pool query.WorkerPool
 }
@@ -75,13 +74,20 @@ func (u *Uniswap) pairsToContractAddresses(pairs []Pair) []string {
 		switch {
 		case match(p, Pair{Base: "COMP", Quote: "WETH"}):
 			names = append(names, "0xcffdded873554f362ac02f8fb1f02e5ada10516f")
-		case match(p, Pair{Base: "LRC", Quote: "WETH"}):
-			names = append(names, "0x8878df9e1a7c87dcbf6d3999d997f262c05d8c70")
+		case match(p, Pair{Base: "WETH", Quote: "USDC"}):
+			names = append(names, "0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc")
 		case match(p, Pair{Base: "KNC", Quote: "WETH"}):
 			names = append(names, "0xf49c43ae0faf37217bdcb00df478cf793edd6687")
+		case match(p, Pair{Base: "LEND", Quote: "WETH"}):
+			names = append(names, "0xab3f9bf1d81ddb224a2014e98b238638824bcf20")
+		case match(p, Pair{Base: "LRC", Quote: "WETH"}):
+			names = append(names, "0x8878df9e1a7c87dcbf6d3999d997f262c05d8c70")
+		case match(p, Pair{Base: "PAXG", Quote: "WETH"}):
+			names = append(names, "0x9c4fe5ffd9a9fc5678cfbd93aa2d4fd684b67c4c")
+		case match(p, Pair{Base: "YFI", Quote: "WETH"}):
+			names = append(names, "0x2fdbadf3c4d5a8666bc06645b8358ab803996e28")
 		}
 	}
-
 	return names
 }
 
@@ -92,8 +98,9 @@ func (u *Uniswap) renameSymbol(symbol string) string {
 		return "WETH"
 	case "BTC":
 		return "WBTC"
+	case "USD":
+		return "USDC"
 	}
-
 	return symbol
 }
 


### PR DESCRIPTION
The GraphAPI supports ERC20 tokens and we used to have to map e.g ETH to WETH, but it is better to explicitly configure it as a 1:1 mapping then to _hack_ it implicitly.

Also, I updated the `gofer.json` to reflect current [`setzer`](https://github.com/makerdao/setzer-mcd/tree/master/libexec/setzer) config.