### PR TITLE
Periodically connect to bootstrap nodes [ch12253]

### DIFF
--- a/internal/p2p/node.go
+++ b/internal/p2p/node.go
@@ -26,13 +26,11 @@ import (
 	"github.com/libp2p/go-libp2p-core/connmgr"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/network"
-	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/peerstore"
 	"github.com/libp2p/go-libp2p-core/transport"
 	"github.com/libp2p/go-libp2p-peerstore/pstoremem"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	swarm "github.com/libp2p/go-libp2p-swarm"
-	"github.com/multiformats/go-multiaddr"
 
 	"github.com/makerdao/oracle-suite/internal/p2p/sets"
 
@@ -179,18 +177,6 @@ func (n *Node) PubSub() *pubsub.PubSub {
 
 func (n *Node) Peerstore() peerstore.Peerstore {
 	return n.peerstore
-}
-
-func (n *Node) Connect(maddr multiaddr.Multiaddr) error {
-	pi, err := peer.AddrInfoFromP2pAddr(maddr)
-	if err != nil {
-		return err
-	}
-	err = n.host.Connect(n.ctx, *pi)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func (n *Node) AddNodeEventHandler(eventHandler ...sets.NodeEventHandler) {

--- a/internal/p2p/options.go
+++ b/internal/p2p/options.go
@@ -179,6 +179,10 @@ func Discovery(bootstrapAddrs []multiaddr.Multiaddr) Options {
 		n.AddNodeEventHandler(sets.NodeEventHandlerFunc(func(event sets.NodeEventType) {
 			switch event {
 			case sets.NodeHostStarted:
+				n.log.
+					WithField("bootstrapAddrs", bootstrapAddrs).
+					Info("Starting KAD-DHT discovery")
+
 				kadDHT, err = dht.New(n.ctx, n.host, dht.BootstrapPeers(addrs...), dht.Mode(dht.ModeServer))
 				if err != nil {
 					n.log.


### PR DESCRIPTION
Peers with disabled _discovery_ feature don't reestablish the lost connection to bootstrap peers. This PR fixes that by adding checking every two minutes if the connection is still maitained.