### PR TITLE
Make sure that bootstrap nodes are not dropped [ch11980]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/libp2p/go-libp2p v0.14.0
 	github.com/libp2p/go-libp2p-asn-util v0.0.0-20210422100720-09a655867a6c // indirect
 	github.com/libp2p/go-libp2p-circuit v0.4.0
+	github.com/libp2p/go-libp2p-connmgr v0.2.4 // indirect
 	github.com/libp2p/go-libp2p-core v0.8.5
 	github.com/libp2p/go-libp2p-discovery v0.5.0
 	github.com/libp2p/go-libp2p-kad-dht v0.12.0

--- a/internal/p2p/node_test.go
+++ b/internal/p2p/node_test.go
@@ -295,7 +295,7 @@ func TestNode_DirectPeers(t *testing.T) {
 		context.Background(),
 		PeerPrivKey(peers[0].PrivKey),
 		ListenAddrs(peers[0].ListenAddrs),
-		ConnectionLimit(0, 0, 0),
+		ConnectionLimit(1, 1, 0),
 		DirectPeers(peers[1].PeerAddrs),
 	)
 	require.NoError(t, err)
@@ -324,10 +324,11 @@ func TestNode_DirectPeers(t *testing.T) {
 		defer n.Stop()
 
 		require.NoError(t, n.Connect(peers[0].PeerAddrs[0]))
+		n1.Host().ConnManager().TagPeer(n.Host().ID(), "test", 1)
 	}
 
 	// The connection between n1 and n2 nodes should be persisted even
-	// with a connection limit set to 0.
+	// with a connection limit.
 	n1.Host().ConnManager().TrimOpenConns(context.Background())
 	time.Sleep(time.Second)
 	assert.Equal(t, network.Connected, n1.Host().Network().Connectedness(n2.Host().ID()))

--- a/internal/p2p/node_test.go
+++ b/internal/p2p/node_test.go
@@ -1,0 +1,404 @@
+package p2p
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/peer"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/makerdao/oracle-suite/pkg/transport"
+)
+
+const defaultTimeout = 10 * time.Second
+
+func TestNode_PeerPrivKey(t *testing.T) {
+	sk, _, _ := crypto.GenerateRSAKeyPair(2048, rand.Reader)
+
+	n, err := NewNode(
+		context.Background(),
+		PeerPrivKey(sk),
+	)
+	require.NoError(t, err)
+	require.NoError(t, n.Start())
+	defer n.Stop()
+
+	id, _ := peer.IDFromPrivateKey(sk)
+	assert.Equal(t, id, n.Host().ID())
+}
+
+func TestNode_MessagePrivKey(t *testing.T) {
+	sk, _, _ := crypto.GenerateRSAKeyPair(2048, rand.Reader)
+
+	n, err := NewNode(
+		context.Background(),
+		MessagePrivKey(sk),
+	)
+	require.NoError(t, err)
+	require.NoError(t, n.Start())
+	defer n.Stop()
+
+	require.NoError(t, n.Subscribe("test", (*Message)(nil)))
+	s, err := n.Subscription("test")
+	require.NoError(t, err)
+
+	err = s.Publish(NewMessage("makerdao"))
+	require.NoError(t, err)
+
+	id, _ := peer.IDFromPrivateKey(sk)
+	msg := <-s.Next()
+	require.NoError(t, msg.Error)
+	assert.Equal(t, id, msg.Data.(*pubsub.Message).GetFrom())
+}
+
+func TestNode_Discovery(t *testing.T) {
+	// This test checks whether all nodes in the network can discover
+	// each other.
+	//
+	// Topology:
+	//   n1 <--[discovery]--> n2 <--[discovery]--> n3
+
+	peers, err := GetPeerInfo(3)
+	require.NoError(t, err)
+
+	n1, err := NewNode(
+		context.Background(),
+		PeerPrivKey(peers[0].PrivKey),
+		ListenAddrs(peers[0].ListenAddrs),
+		Discovery(nil),
+	)
+	require.NoError(t, err)
+	require.NoError(t, n1.Start())
+	defer n1.Stop()
+
+	n2, err := NewNode(
+		context.Background(),
+		PeerPrivKey(peers[1].PrivKey),
+		ListenAddrs(peers[1].ListenAddrs),
+		Discovery(peers[0].PeerAddrs),
+	)
+	require.NoError(t, err)
+	require.NoError(t, n2.Start())
+	defer n2.Stop()
+
+	n3, err := NewNode(
+		context.Background(),
+		PeerPrivKey(peers[2].PrivKey),
+		ListenAddrs(peers[2].ListenAddrs),
+		Discovery(peers[0].PeerAddrs),
+	)
+	require.NoError(t, err)
+	require.NoError(t, n3.Start())
+	defer n3.Stop()
+
+	require.NoError(t, n1.Subscribe("test", (*Message)(nil)))
+	require.NoError(t, n2.Subscribe("test", (*Message)(nil)))
+	require.NoError(t, n3.Subscribe("test", (*Message)(nil)))
+
+	// Every peer should see two other peers:
+	WaitFor(t, func() bool {
+		lp := n1.PubSub().ListPeers("test")
+		return ContainsPeerID(lp, peers[1].ID) && ContainsPeerID(lp, peers[2].ID)
+	}, defaultTimeout)
+	WaitFor(t, func() bool {
+		lp := n2.PubSub().ListPeers("test")
+		return ContainsPeerID(lp, peers[0].ID) && ContainsPeerID(lp, peers[2].ID)
+	}, defaultTimeout)
+	WaitFor(t, func() bool {
+		lp := n3.PubSub().ListPeers("test")
+		return ContainsPeerID(lp, peers[0].ID) && ContainsPeerID(lp, peers[1].ID)
+	}, defaultTimeout)
+}
+
+func TestNode_AddrNotLeaking(t *testing.T) {
+	// This test checks that the addresses of nodes that do not use discovery
+	// are not revealed to other nodes in the network.
+	//
+	// Topology:
+	//   n1 <--[discovery]--> n2 <--[direct]--> n3
+	//
+	// - n1 node should only be connected to n2 node (through discovery)
+	// - n2 node should only be connected to n1 node (through discovery) and n2 (through direct connection)
+	// - n3 node should only be connected to n2 node (through direct connection)
+	// - the n1 node's address must not be exposed to n3 node
+
+	peers, err := GetPeerInfo(3)
+	require.NoError(t, err)
+
+	n1, err := NewNode(
+		context.Background(),
+		PeerPrivKey(peers[0].PrivKey),
+		ListenAddrs(peers[0].ListenAddrs),
+		Discovery(nil),
+	)
+	require.NoError(t, err)
+	require.NoError(t, n1.Start())
+	defer n1.Stop()
+
+	n2, err := NewNode(
+		context.Background(),
+		PeerPrivKey(peers[1].PrivKey),
+		ListenAddrs(peers[1].ListenAddrs),
+		DirectPeers(peers[2].PeerAddrs),
+		Discovery(peers[0].PeerAddrs),
+	)
+	require.NoError(t, err)
+	require.NoError(t, n2.Start())
+	defer n2.Stop()
+
+	n3, err := NewNode(
+		context.Background(),
+		PeerPrivKey(peers[2].PrivKey),
+		ListenAddrs(peers[2].ListenAddrs),
+		DirectPeers(peers[1].PeerAddrs),
+	)
+	require.NoError(t, err)
+	require.NoError(t, n3.Start())
+	defer n3.Stop()
+
+	require.NoError(t, n1.Subscribe("test", (*Message)(nil)))
+	require.NoError(t, n2.Subscribe("test", (*Message)(nil)))
+	require.NoError(t, n3.Subscribe("test", (*Message)(nil)))
+
+	WaitFor(t, func() bool {
+		lp := n1.PubSub().ListPeers("test")
+		return len(lp) == 1 && ContainsPeerID(lp, peers[1].ID)
+	}, defaultTimeout)
+	WaitFor(t, func() bool {
+		lp := n2.PubSub().ListPeers("test")
+		return len(lp) == 2 && ContainsPeerID(lp, peers[0].ID) && ContainsPeerID(lp, peers[2].ID)
+	}, defaultTimeout)
+	WaitFor(t, func() bool {
+		lp := n3.PubSub().ListPeers("test")
+		return len(lp) == 1 && ContainsPeerID(lp, peers[1].ID)
+	}, defaultTimeout)
+}
+
+func TestNode_MessagePropagation(t *testing.T) {
+	// This test checks if messages are propagated between peers correctly.
+	//
+	// Topology:
+	//   n1 <--[manual connection]--> n2
+
+	peers, err := GetPeerInfo(2)
+	require.NoError(t, err)
+
+	n1, err := NewNode(
+		context.Background(),
+		PeerPrivKey(peers[0].PrivKey),
+		ListenAddrs(peers[0].ListenAddrs),
+	)
+	require.NoError(t, err)
+	require.NoError(t, n1.Start())
+	defer n1.Stop()
+
+	n2, err := NewNode(
+		context.Background(),
+		PeerPrivKey(peers[1].PrivKey),
+		ListenAddrs(peers[1].ListenAddrs),
+	)
+	require.NoError(t, err)
+	require.NoError(t, n2.Start())
+	defer n2.Stop()
+
+	require.NoError(t, n1.Connect(peers[1].PeerAddrs[0]))
+	require.NoError(t, n1.Subscribe("test", (*Message)(nil)))
+	require.NoError(t, n2.Subscribe("test", (*Message)(nil)))
+
+	WaitFor(t, func() bool {
+		return len(n1.PubSub().ListPeers("test")) > 0 && len(n2.PubSub().ListPeers("test")) > 0
+	}, defaultTimeout)
+
+	s1, err := n1.Subscription("test")
+	require.NoError(t, err)
+	s2, err := n2.Subscription("test")
+	require.NoError(t, err)
+
+	err = s1.Publish(NewMessage("makerdao"))
+	assert.NoError(t, err)
+
+	// Message should be received on both nodes:
+	WaitForMessage(t, s1.Next(), NewMessage("makerdao"), defaultTimeout)
+	WaitForMessage(t, s2.Next(), NewMessage("makerdao"), defaultTimeout)
+}
+
+func TestNode_ConnectionLimit(t *testing.T) {
+	peers, err := GetPeerInfo(5)
+	require.NoError(t, err)
+
+	n1, err := NewNode(
+		context.Background(),
+		PeerPrivKey(peers[0].PrivKey),
+		ListenAddrs(peers[0].ListenAddrs),
+		ConnectionLimit(1, 1, 0),
+		DirectPeers(peers[1].PeerAddrs),
+	)
+	require.NoError(t, err)
+	require.NoError(t, n1.Start())
+	defer n1.Stop()
+
+	n2, err := NewNode(
+		context.Background(),
+		PeerPrivKey(peers[1].PrivKey),
+		ListenAddrs(peers[1].ListenAddrs),
+		DirectPeers(peers[0].PeerAddrs),
+	)
+	require.NoError(t, err)
+	require.NoError(t, n2.Start())
+	defer n2.Stop()
+
+	for i := 2; i < len(peers); i++ {
+		n, err := NewNode(
+			context.Background(),
+			PeerPrivKey(peers[i].PrivKey),
+			ListenAddrs(peers[i].ListenAddrs),
+			Discovery(nil),
+		)
+		require.NoError(t, err)
+		require.NoError(t, n.Start())
+		defer n.Stop()
+
+		require.NoError(t, n.Connect(peers[0].PeerAddrs[0]))
+	}
+
+	n1.Host().ConnManager().TrimOpenConns(context.Background())
+	time.Sleep(time.Second)
+
+	conns := 0
+	for _, p := range n1.Host().Peerstore().Peers() {
+		if n1.Host().Network().Connectedness(p) == network.Connected {
+			conns++
+		}
+	}
+
+	// There is a limit of 1 connection, but direct peers aren't counted,
+	// so the total number of connections should be 2:
+	assert.Equal(t, conns, 2)
+}
+
+// Message is the simplest implementation of the transport.Message interface.
+type Message []byte
+
+// NewMessage Returns a new Message.
+func NewMessage(msg string) *Message {
+	b := Message(msg)
+	return &b
+}
+
+func (m *Message) String() string {
+	if m == nil {
+		return ""
+	}
+	return string(*m)
+}
+
+func (m *Message) Marshall() ([]byte, error) {
+	return *m, nil
+}
+
+func (m *Message) Unmarshall(bytes []byte) error {
+	*m = bytes
+	return nil
+}
+
+type PeerInfo struct {
+	ID          peer.ID
+	PrivKey     crypto.PrivKey
+	ListenAddrs []multiaddr.Multiaddr
+	PeerAddrs   []multiaddr.Multiaddr
+}
+
+// GetPeerInfo returns n PeerInfo structs which can be used to generate
+// random test nodes.
+func GetPeerInfo(n int) ([]PeerInfo, error) {
+	ps, err := GetFreePorts(n)
+	if err != nil {
+		return nil, err
+	}
+	var pi []PeerInfo
+	for i := 0; i < n; i++ {
+		rr := rand.Reader
+		sk, _, err := crypto.GenerateEd25519Key(rr)
+		if err != nil {
+			return nil, err
+		}
+		id, err := peer.IDFromPrivateKey(sk)
+		if err != nil {
+			return nil, err
+		}
+		pi = append(pi, PeerInfo{
+			ListenAddrs: []multiaddr.Multiaddr{multiaddr.StringCast(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", ps[i]))},
+			PeerAddrs:   []multiaddr.Multiaddr{multiaddr.StringCast(fmt.Sprintf("/ip4/127.0.0.1/tcp/%d/p2p/%s", ps[i], id.Pretty()))},
+			PrivKey:     sk,
+			ID:          id,
+		})
+	}
+	return pi, nil
+}
+
+// GetFreePorts returns n random ports available to use.
+func GetFreePorts(n int) ([]int, error) {
+	var ports []int
+	for i := 0; i < n; i++ {
+		addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
+		if err != nil {
+			return nil, err
+		}
+		l, err := net.ListenTCP("tcp", addr)
+		if err != nil {
+			return nil, err
+		}
+		defer l.Close()
+		ports = append(ports, l.Addr().(*net.TCPAddr).Port)
+	}
+	return ports, nil
+}
+
+func WaitFor(t *testing.T, cond func() bool, timeout time.Duration) {
+	s := time.Now()
+	for !cond() {
+		if time.Since(s) >= timeout {
+			assert.Fail(t, "timeout")
+			return
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+func WaitForMessage(t *testing.T, stat chan transport.ReceivedMessage, expected *Message, timeout time.Duration) {
+	to := time.After(timeout)
+	select {
+	case received := <-stat:
+		require.NoError(t, received.Error, "subscription returned an error")
+		receivedBts, err := received.Message.Marshall()
+		if err != nil {
+			assert.NoError(t, err, "unable to unmarshall received message")
+		}
+		expectedBts, err := expected.Marshall()
+		if err != nil {
+			assert.NoError(t, err, "unable to unmarshall expected message")
+		}
+		assert.Equal(t, expectedBts, receivedBts)
+	case <-to:
+		assert.Fail(t, "timeout")
+		return
+	}
+}
+
+func ContainsPeerID(ids []peer.ID, id peer.ID) bool {
+	for _, i := range ids {
+		if i == id {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/p2p/options.go
+++ b/internal/p2p/options.go
@@ -19,6 +19,7 @@ import (
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/peerstore"
 	discovery "github.com/libp2p/go-libp2p-discovery"
 	dht "github.com/libp2p/go-libp2p-kad-dht"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -130,6 +131,7 @@ func Discovery(bootstrapAddrs []multiaddr.Multiaddr) Options {
 					// bootstrap nodes aren't protected by KAD-DHT so we have
 					// do it manually
 					n.connmgr.Protect(addr.ID, "bootstrap")
+					n.peerstore.AddAddrs(addr.ID, addr.Addrs, peerstore.PermanentAddrTTL)
 				}
 				kadDHT, err = dht.New(n.ctx, n.host, dht.BootstrapPeers(addrs...), dht.Mode(dht.ModeServer))
 				if err != nil {

--- a/internal/p2p/options.go
+++ b/internal/p2p/options.go
@@ -126,7 +126,11 @@ func Discovery(bootstrapAddrs []multiaddr.Multiaddr) Options {
 				n.log.
 					WithField("bootstrapAddrs", bootstrapAddrs).
 					Info("Starting KAD-DHT discovery")
-
+				for _, addr := range addrs {
+					// bootstrap nodes aren't protected by KAD-DHT so we have
+					// do it manually
+					n.connmgr.Protect(addr.ID, "bootstrap")
+				}
 				kadDHT, err = dht.New(n.ctx, n.host, dht.BootstrapPeers(addrs...), dht.Mode(dht.ModeServer))
 				if err != nil {
 					n.log.

--- a/internal/p2p/options.go
+++ b/internal/p2p/options.go
@@ -16,7 +16,10 @@
 package p2p
 
 import (
+	"time"
+
 	"github.com/libp2p/go-libp2p"
+	connmgr "github.com/libp2p/go-libp2p-connmgr"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/peerstore"
@@ -83,10 +86,20 @@ func UserAgent(userAgent string) Options {
 	}
 }
 
-// DirectPeers is a gossipsub router option that specifies peers with direct
-// peering agreements. These peers are connected outside of the mesh, with all (valid)
+// ConnectionLimit limits the number of connections. When the number of
+// connections reaches a high value, then as many connections will be
+// dropped until we reach a low number of connections.
+func ConnectionLimit(low, high int, grace time.Duration) Options {
+	return func(n *Node) error {
+		n.connmgr = connmgr.NewConnManager(low, high, grace)
+		return nil
+	}
+}
+
+// DirectPeers is a gossipsub router option that specifies getPeerInfos with direct
+// peering agreements. These getPeerInfos are connected outside of the mesh, with all (valid)
 // message unconditionally forwarded to them. The router will maintain open connections
-// to these peers. Note that the peering agreement should be reciprocal with direct peers
+// to these getPeerInfos. Note that the peering agreement should be reciprocal with direct getPeerInfos
 // symmetrically configured at both ends.
 func DirectPeers(addrs []multiaddr.Multiaddr) Options {
 	return func(n *Node) error {

--- a/internal/p2p/options_denylist.go
+++ b/internal/p2p/options_denylist.go
@@ -29,6 +29,10 @@ import (
 // Denylist allows to block peer by their IP addresses or IDs.
 func Denylist(addrs []multiaddr.Multiaddr) Options {
 	return func(n *Node) error {
+		if len(addrs) == 0 {
+			return nil
+		}
+
 		cg := &denylistConnGater{log: n.log}
 		n.AddConnectionGater(cg)
 		for _, maddr := range addrs {

--- a/internal/p2p/options_peer_logger.go
+++ b/internal/p2p/options_peer_logger.go
@@ -24,7 +24,7 @@ import (
 	"github.com/makerdao/oracle-suite/pkg/log"
 )
 
-// PeerLogger logs all peers handled by libp2p's pubsub system.
+// PeerLogger logs all getPeerInfos handled by libp2p's pubsub system.
 func PeerLogger() Options {
 	return func(n *Node) error {
 		n.AddPubSubEventHandler(sets.PubSubEventHandlerFunc(func(topic string, event pubsub.PeerEvent) {
@@ -39,7 +39,7 @@ func PeerLogger() Options {
 					WithFields(log.Fields{
 						"peerID":          event.Peer.String(),
 						"topic":           topic,
-						"addrs":           addrs,
+						"listenAddrs":     addrs,
 						"userAgent":       ua,
 						"protocolVersion": pv,
 						"protocols":       pp,
@@ -48,9 +48,9 @@ func PeerLogger() Options {
 			case pubsub.PeerLeave:
 				n.log.
 					WithFields(log.Fields{
-						"peerID": event.Peer.String(),
-						"topic":  topic,
-						"addrs":  addrs,
+						"peerID":      event.Peer.String(),
+						"topic":       topic,
+						"listenAddrs": addrs,
 					}).
 					Info("Disconnected from a peer")
 			}

--- a/pkg/ghost/config/config.go
+++ b/pkg/ghost/config/config.go
@@ -62,6 +62,7 @@ type P2P struct {
 	PrivKeySeed      string   `json:"privKeySeed"`
 	ListenAddrs      []string `json:"listenAddrs"`
 	BootstrapAddrs   []string `json:"bootstrapAddrs"`
+	DirectPeersAddrs []string `json:"directPeersAddrs"`
 	BlockedAddrs     []string `json:"blockedAddrs"`
 	DisableDiscovery bool     `json:"disableDiscovery"`
 }
@@ -144,15 +145,16 @@ func (c *Config) configureTransport(ctx context.Context, s ethereum.Signer, l lo
 	}
 
 	cfg := p2p.Config{
-		Context:        ctx,
-		PeerPrivKey:    peerPrivKey,
-		MessagePrivKey: ethkey.NewPrivKey(s),
-		ListenAddrs:    c.P2P.ListenAddrs,
-		BootstrapAddrs: c.P2P.BootstrapAddrs,
-		BlockedAddrs:   c.P2P.BlockedAddrs,
-		Discovery:      !c.P2P.DisableDiscovery,
-		Signer:         s,
-		Logger:         l,
+		Context:          ctx,
+		PeerPrivKey:      peerPrivKey,
+		MessagePrivKey:   ethkey.NewPrivKey(s),
+		ListenAddrs:      c.P2P.ListenAddrs,
+		BootstrapAddrs:   c.P2P.BootstrapAddrs,
+		DirectPeersAddrs: c.P2P.DirectPeersAddrs,
+		BlockedAddrs:     c.P2P.BlockedAddrs,
+		Discovery:        !c.P2P.DisableDiscovery,
+		Signer:           s,
+		Logger:           l,
 	}
 	cfg.FeedersAddrs = []ethereum.Address{ethereum.HexToAddress(c.Ethereum.From)}
 	for _, feed := range c.Feeds {

--- a/pkg/spectre/config/config.go
+++ b/pkg/spectre/config/config.go
@@ -64,6 +64,7 @@ type P2P struct {
 	PrivKeySeed      string   `json:"privKeySeed"`
 	ListenAddrs      []string `json:"listenAddrs"`
 	BootstrapAddrs   []string `json:"bootstrapAddrs"`
+	DirectPeersAddrs []string `json:"directPeersAddrs"`
 	BlockedAddrs     []string `json:"blockedAddrs"`
 	DisableDiscovery bool     `json:"disableDiscovery"`
 }
@@ -158,14 +159,15 @@ func (c *Config) configureTransport(ctx context.Context, s ethereum.Signer, l lo
 	// Spectre doesn't create any messages so there is no need to
 	// configure the MessagePrivKey field.
 	cfg := p2p.Config{
-		Context:        ctx,
-		PeerPrivKey:    peerPrivKey,
-		ListenAddrs:    c.P2P.ListenAddrs,
-		BootstrapAddrs: c.P2P.BootstrapAddrs,
-		BlockedAddrs:   c.P2P.BlockedAddrs,
-		Discovery:      !c.P2P.DisableDiscovery,
-		Signer:         s,
-		Logger:         l,
+		Context:          ctx,
+		PeerPrivKey:      peerPrivKey,
+		ListenAddrs:      c.P2P.ListenAddrs,
+		BootstrapAddrs:   c.P2P.BootstrapAddrs,
+		DirectPeersAddrs: c.P2P.DirectPeersAddrs,
+		BlockedAddrs:     c.P2P.BlockedAddrs,
+		Discovery:        !c.P2P.DisableDiscovery,
+		Signer:           s,
+		Logger:           l,
 	}
 	for _, feed := range c.Feeds {
 		cfg.FeedersAddrs = append(cfg.FeedersAddrs, ethereum.HexToAddress(feed))

--- a/pkg/spire/config/config.go
+++ b/pkg/spire/config/config.go
@@ -60,6 +60,7 @@ type P2P struct {
 	PrivKeySeed      string   `json:"privKeySeed"`
 	ListenAddrs      []string `json:"listenAddrs"`
 	BootstrapAddrs   []string `json:"bootstrapAddrs"`
+	DirectPeersAddrs []string `json:"directPeersAddrs"`
 	BlockedAddrs     []string `json:"blockedAddrs"`
 	DisableDiscovery bool     `json:"disableDiscovery"`
 }
@@ -157,15 +158,16 @@ func (c *Config) configureTransport(ctx context.Context, s ethereum.Signer, l lo
 	}
 
 	cfg := p2p.Config{
-		Context:        ctx,
-		PeerPrivKey:    peerPrivKey,
-		MessagePrivKey: ethkey.NewPrivKey(s),
-		ListenAddrs:    c.P2P.ListenAddrs,
-		BootstrapAddrs: c.P2P.BootstrapAddrs,
-		BlockedAddrs:   c.P2P.BlockedAddrs,
-		Discovery:      !c.P2P.DisableDiscovery,
-		Signer:         s,
-		Logger:         l,
+		Context:          ctx,
+		PeerPrivKey:      peerPrivKey,
+		MessagePrivKey:   ethkey.NewPrivKey(s),
+		ListenAddrs:      c.P2P.ListenAddrs,
+		BootstrapAddrs:   c.P2P.BootstrapAddrs,
+		DirectPeersAddrs: c.P2P.DirectPeersAddrs,
+		BlockedAddrs:     c.P2P.BlockedAddrs,
+		Discovery:        !c.P2P.DisableDiscovery,
+		Signer:           s,
+		Logger:           l,
 	}
 	cfg.FeedersAddrs = []ethereum.Address{ethereum.HexToAddress(c.Ethereum.From)}
 	for _, feed := range c.Feeds {

--- a/pkg/transport/p2p/p2p.go
+++ b/pkg/transport/p2p/p2p.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/multiformats/go-multiaddr"
@@ -31,6 +32,8 @@ import (
 
 const LoggerTag = "P2P"
 const userAgentString = "spire/v0.0-dev"
+const lowPeers = 100
+const highPeers = 150
 
 // defaultListenAddrs is a list of default multiaddresses on which node will
 // be listening on.
@@ -111,6 +114,7 @@ func New(cfg Config) (*P2P, error) {
 		p2p.ListenAddrs(listenAddrs),
 		p2p.DirectPeers(directPeersAddrs),
 		p2p.Denylist(blockedAddrs),
+		p2p.ConnectionLimit(lowPeers, highPeers, 5*time.Minute),
 		p2p.Logger(logger),
 		p2p.ConnectionLogger(),
 		p2p.MessageLogger(),
@@ -169,11 +173,14 @@ func (p *P2P) Broadcast(topic string, message transport.Message) error {
 }
 
 // WaitFor implements the transport.Transport interface.
-func (p *P2P) WaitFor(topic string) chan transport.Status {
+func (p *P2P) WaitFor(topic string) chan transport.ReceivedMessage {
 	sub, err := p.node.Subscription(topic)
 	if err != nil {
 		return nil
 	}
+	go func() {
+
+	}()
 	return sub.Next()
 }
 

--- a/pkg/transport/p2p/p2p.go
+++ b/pkg/transport/p2p/p2p.go
@@ -17,6 +17,8 @@ package p2p
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/multiformats/go-multiaddr"
@@ -33,6 +35,8 @@ const userAgentString = "spire/v0.0-dev"
 // defaultListenAddrs is a list of default multiaddresses on which node will
 // be listening on.
 var defaultListenAddrs = []string{"/ip4/0.0.0.0/tcp/0"}
+
+var ErrP2P = errors.New("P2P transport error")
 
 // P2P is a little wrapper for the Node that implements the Transport
 // interface.
@@ -54,7 +58,12 @@ type Config struct {
 	// listening on. If empty, the localhost, and a random port will be used.
 	ListenAddrs []string
 	// BootstrapAddrs is a list multiaddresses of initial peers to connect to.
+	// This option is ignored when discovery is disabled.
 	BootstrapAddrs []string
+	// DirectPeersAddrs is a list multiaddresses of peers to which messages
+	// will be send directly. This option have to be configured symmetrically
+	// at both ends.
+	DirectPeersAddrs []string
 	// BlockedAddrs is a list of multiaddresses to which connection will be
 	// blocked. If an address on that list contains an IP and a peer ID, both
 	// will be blocked separately.
@@ -62,7 +71,9 @@ type Config struct {
 	// FeedersAddrs is a list of price feeders. Only feeders can create new
 	// messages in the network.
 	FeedersAddrs []ethereum.Address
-	// Discovery indicates whenever Discovery should be enabled.
+	// Discovery indicates whenever peer discovery should be enabled.
+	// If discovery is disabled, then DirectPeersAddrs must be used
+	// to connect to the network.
 	Discovery bool
 	// Signer used to verify price messages.
 	Signer ethereum.Signer
@@ -79,21 +90,26 @@ func New(cfg Config) (*P2P, error) {
 
 	listenAddrs, err := strsToMaddrs(cfg.ListenAddrs)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%v: unable to parse listenAddrs: %v", ErrP2P, err)
 	}
 	bootstrapAddrs, err := strsToMaddrs(cfg.BootstrapAddrs)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%v: unable to parse bootstrapAddrs: %v", ErrP2P, err)
+	}
+	directPeersAddrs, err := strsToMaddrs(cfg.DirectPeersAddrs)
+	if err != nil {
+		return nil, fmt.Errorf("%v: unable to parse directPeersAddrs: %v", ErrP2P, err)
 	}
 	blockedAddrs, err := strsToMaddrs(cfg.BlockedAddrs)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%v: unable to parse blockedAddrs: %v", ErrP2P, err)
 	}
 
 	logger := cfg.Logger.WithField("tag", LoggerTag)
 	opts := []p2p.Options{
 		p2p.UserAgent(userAgentString),
 		p2p.ListenAddrs(listenAddrs),
+		p2p.DirectPeers(directPeersAddrs),
 		p2p.Denylist(blockedAddrs),
 		p2p.Logger(logger),
 		p2p.ConnectionLogger(),
@@ -101,30 +117,25 @@ func New(cfg Config) (*P2P, error) {
 		p2p.PeerLogger(),
 		oracle(cfg.FeedersAddrs, cfg.Signer, logger),
 	}
-
 	if cfg.PeerPrivKey != nil {
 		opts = append(opts, p2p.PeerPrivKey(cfg.PeerPrivKey))
 	}
-
 	if cfg.MessagePrivKey != nil {
 		opts = append(opts, p2p.MessagePrivKey(cfg.MessagePrivKey))
 	}
-
 	if cfg.Discovery {
 		opts = append(opts, p2p.Discovery(bootstrapAddrs))
-	} else {
-		opts = append(opts, p2p.Bootstrap(bootstrapAddrs))
 	}
 
 	n, err := p2p.NewNode(cfg.Context, opts...)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%v: unable to initialize node: %v", ErrP2P, err)
 	}
 
 	p := &P2P{node: n}
 	err = p.node.Start()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%v: unable to start node: %v", ErrP2P, err)
 	}
 
 	return p, nil
@@ -132,19 +143,27 @@ func New(cfg Config) (*P2P, error) {
 
 // Subscribe implements the transport.Transport interface.
 func (p *P2P) Subscribe(topic string, typ transport.Message) error {
-	return p.node.Subscribe(topic, typ)
+	err := p.node.Subscribe(topic, typ)
+	if err != nil {
+		return fmt.Errorf("%v: unable to subscribe to topic %s: %v", ErrP2P, topic, err)
+	}
+	return nil
 }
 
 // Unsubscribe implements the transport.Transport interface.
 func (p *P2P) Unsubscribe(topic string) error {
-	return p.node.Unsubscribe(topic)
+	err := p.node.Unsubscribe(topic)
+	if err != nil {
+		return fmt.Errorf("%v: unable to unsubscribe from topic %s: %v", ErrP2P, topic, err)
+	}
+	return nil
 }
 
 // Broadcast implements the transport.Transport interface.
 func (p *P2P) Broadcast(topic string, message transport.Message) error {
 	sub, err := p.node.Subscription(topic)
 	if err != nil {
-		return err
+		return fmt.Errorf("%v: unable to get subscription for %s topic: %v", ErrP2P, topic, err)
 	}
 	return sub.Publish(message)
 }

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -15,8 +15,9 @@
 
 package transport
 
-type Status struct {
+type ReceivedMessage struct {
 	Message Message
+	Data    interface{}
 	Error   error
 }
 
@@ -40,7 +41,7 @@ type Transport interface {
 	// be supported by this method, for unsubscribed topic nil will be
 	// returned. In case of an error, error will be returned in a Status
 	// structure.
-	WaitFor(topic string) chan Status
+	WaitFor(topic string) chan ReceivedMessage
 	// Close closes connection.
 	Close() error
 }


### PR DESCRIPTION
This PR removes a previous method used to maintain a direct connection between peers and replaces it with libp2p's `DirectPeer` feature which is a proper way to achieve this. Also, I finally added tests for the p2p pkg.